### PR TITLE
[FEAT]: 도서 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,5 @@ out/
 /src/main/resources/oauth2/
 /src/main/resources/webclient/
 /src/main/resources/s3/
+/src/main/resources/book/
 

--- a/src/main/java/com/nookbook/NookBookApplication.java
+++ b/src/main/java/com/nookbook/NookBookApplication.java
@@ -13,6 +13,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @PropertySource(value = { "classpath:swagger/application-springdoc.yml" }, factory = YamlPropertySourceFactory.class)
 @PropertySource(value = { "classpath:oauth2/application-oauth2.yml" }, factory = YamlPropertySourceFactory.class)
 @PropertySource(value = { "classpath:s3/application-s3.yml" }, factory = YamlPropertySourceFactory.class)
+@PropertySource(value = { "classpath:book/application-book.yml" }, factory = YamlPropertySourceFactory.class)
 public class NookBookApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/nookbook/domain/book/applicaiton/AladinService.java
+++ b/src/main/java/com/nookbook/domain/book/applicaiton/AladinService.java
@@ -95,11 +95,9 @@ public class AladinService {
         return userOptional.get();
     }
 
-
-    // 카테고리별
-
-    // 베스트셀러
-    public ResponseEntity<?> getBestSeller(int page) {
+    // 베스트셀러 + 카테고리
+    // 종합(0), 소설(1), 경제/경영(170), 자기계발(336), 시(50940), 에세이(55889), 인문/교양(656), 취미/실용(55890), 매거진(2913)
+    public ResponseEntity<?> getBestSellerByCategory(int page, int category, int size) {
         RestTemplate restTemplate = new RestTemplate();
         // 기본 헤더 설정 (필요에 따라)
         HttpHeaders headers = new HttpHeaders();
@@ -113,7 +111,8 @@ public class AladinService {
                 .queryParam("QueryType", "Bestseller")
                 .queryParam("SearchTarget", "Book")
                 .queryParam("start", page)
-                .queryParam("MaxResults", 12)
+                .queryParam("MaxResults", size)
+                .queryParam("CategoryId", category)
                 .queryParam("output", "JS")
                 .queryParam("Version", 20131101)
                 .build()

--- a/src/main/java/com/nookbook/domain/book/applicaiton/AladinService.java
+++ b/src/main/java/com/nookbook/domain/book/applicaiton/AladinService.java
@@ -1,0 +1,75 @@
+package com.nookbook.domain.book.applicaiton;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nookbook.domain.book.dto.response.SearchRes;
+import com.nookbook.global.config.security.token.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AladinService {
+
+    // ttb 키 value로
+    @Value("${aladin.ttb.key}")
+    private String KEY;
+
+    @Value("${aladin.search-url}")
+    private String SEARCH_URL;
+
+    // 검색
+    public ResponseEntity<?> searchBooks(String keyword, int page) {
+        RestTemplate restTemplate = new RestTemplate();
+        // 기본 헤더 설정 (필요에 따라)
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+        HttpEntity<String> httpEntity = new HttpEntity<>(headers);
+
+        // 요청 URL 구성
+        URI searchUrl = UriComponentsBuilder
+                .fromUriString(SEARCH_URL)
+                .queryParam("ttbkey", KEY)
+                .queryParam("Query", keyword)
+                .queryParam("QueryType", "Keyword")
+                .queryParam("QueryType", "Publisher")
+                .queryParam("start", page)
+                .queryParam("MaxResults", 10)
+                .queryParam("output", "JS")
+                .queryParam("Version", 20131101)
+                .build()
+                .encode(StandardCharsets.UTF_8)
+                .toUri();
+        // API 호출 및 응답 처리
+        ResponseEntity<String> responseEntity = restTemplate.exchange(searchUrl, HttpMethod.GET, httpEntity, String.class);
+        String responseBody = responseEntity.getBody();
+
+        // JSON 파싱 및 DTO 변환
+        SearchRes searchRes = convertToSearchRes(responseBody);
+
+        return ResponseEntity.ok(searchRes);
+    }
+
+    private SearchRes convertToSearchRes(String json) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            // JSON 문자열을 SearchRes 객체로 변환
+            return objectMapper.readValue(json, SearchRes.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new SearchRes(); // 오류 발생 시 빈 객체 반환
+        }
+    }
+
+
+    // 카테고리별
+    // 베스트셀러
+}

--- a/src/main/java/com/nookbook/domain/book/applicaiton/AladinService.java
+++ b/src/main/java/com/nookbook/domain/book/applicaiton/AladinService.java
@@ -1,13 +1,22 @@
 package com.nookbook.domain.book.applicaiton;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nookbook.domain.book.domain.Book;
+import com.nookbook.domain.book.domain.repository.BookRepository;
 import com.nookbook.domain.book.dto.response.BestSellerRes;
+import com.nookbook.domain.book.dto.response.BookDetailRes;
+import com.nookbook.domain.book.dto.response.BookRes;
 import com.nookbook.domain.book.dto.response.SearchRes;
 import com.nookbook.domain.keyword.application.KeywordService;
 import com.nookbook.domain.user.domain.User;
 import com.nookbook.domain.user.domain.repository.UserRepository;
+import com.nookbook.domain.user_book.domain.BookStatus;
+import com.nookbook.domain.user_book.domain.UserBook;
+import com.nookbook.domain.user_book.domain.repository.UserBookRepository;
 import com.nookbook.global.DefaultAssert;
 import com.nookbook.global.config.security.token.UserPrincipal;
+import com.nookbook.global.payload.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
@@ -18,7 +27,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +35,9 @@ import java.util.Optional;
 public class AladinService {
 
     private final UserRepository userRepository;
+    private final BookRepository bookRepository;
+    private final UserBookRepository userBookRepository;
+
     private final KeywordService keywordService;
 
     // ttb 키 value로
@@ -138,5 +150,120 @@ public class AladinService {
             return new BestSellerRes(); // 오류 발생 시 빈 객체 반환
         }
     }
+
+    // 상세 조회
+    public ResponseEntity<?> getBookDetail(UserPrincipal userPrincipal, String isbn13) {
+        User user = validUserById(userPrincipal.getId());
+        BookStatus bookStatus = BookStatus.BEFORE_READING;
+        boolean isStoredCollection = false;
+
+        BookRes bookRes;
+        if (bookRepository.existsByIsbn(isbn13)) {
+            Book book = bookRepository.findByIsbn(isbn13);
+
+            Optional<UserBook> userBookOptional = userBookRepository.findByUserAndBook(user, book);
+            if (userBookOptional.isPresent()) {
+                bookStatus = userBookOptional.get().getBookStatus();
+            }
+            // 컬렉션 저장 여부 확인
+            // Optional<Collection> collectionOptional = collectionRepository.findByUserAndIsbn(user, isbn13);
+            // if (collectionOptional.isPresent()) {
+            //     isStoredCollection = true; // 컬렉션에 저장된 상태
+            // }
+
+            BookDetailRes bookDetailRes = BookDetailRes.builder()
+                    .title(book.getTitle())
+                    .author(book.getAuthor())
+                    .cover(book.getImage())
+                    .isbn13(isbn13)
+                    .page(book.getPage())
+                    .pubDate(book.getPublishedDate().toString())
+                    .description(book.getInfo())
+                    .toc(book.getIdx())
+                    .link(book.getLink())
+                    .build();
+
+            bookRes = BookRes.builder()
+                    .bookStatus(bookStatus)
+                    .storedCollection(isStoredCollection)
+                    .item(bookDetailRes)
+                    .build();
+        } else {
+            bookRes = getBookInfoByISBN(isbn13);
+            // 추가로 bookStatus, storedCollection 설정
+            bookRes.setBookStatus(bookStatus);
+            bookRes.setStoredCollection(isStoredCollection);
+        }
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(bookRes)
+                .build();
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    private BookRes getBookInfoByISBN(String isbn13) {
+        RestTemplate restTemplate = new RestTemplate();
+        // 기본 헤더 설정 (필요에 따라)
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+        HttpEntity<String> httpEntity = new HttpEntity<>(headers);
+
+        // 요청 URL 구성
+        URI requestUrl = UriComponentsBuilder
+                .fromUriString(FIND_URL)
+                .queryParam("ttbkey", KEY)
+                .queryParam("ItemId", isbn13)
+                .queryParam("itemIdType", "ISBN13")
+                .queryParam("output", "JS")
+                .queryParam("Version", 20131101)
+                .queryParam("OptResult", "Toc,fulldescription")
+                .build()
+                .encode(StandardCharsets.UTF_8)
+                .toUri();
+        // API 호출 및 응답 처리
+        ResponseEntity<String> responseEntity = restTemplate.exchange(requestUrl, HttpMethod.GET, httpEntity, String.class);
+        String responseBody = responseEntity.getBody();
+
+        // JSON 파싱 및 DTO 변환
+        return convertToBookRes(responseBody);
+    }
+
+    private BookRes convertToBookRes(String json) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            // JSON 문자열을 Map 형태로 변환
+            Map<String, Object> map = objectMapper.readValue(json, new TypeReference<>() {});
+
+            // "item" 배열을 추출
+            List<Map<String, Object>> items = (List<Map<String, Object>>) map.get("item");
+
+            // 첫 번째 아이템을 BookDetailRes로 변환
+            BookDetailRes bookDetailRes = null;
+            if (items != null && !items.isEmpty()) {
+                Map<String, Object> item = items.get(0);
+                bookDetailRes = objectMapper.convertValue(item, BookDetailRes.class);
+
+                // subInfo를 추출하고 itemPage 값을 설정
+                Map<String, Object> subInfo = (Map<String, Object>) item.get("subInfo");
+                if (subInfo != null) {
+                    int itemPage = (Integer) subInfo.get("itemPage");
+                    String toc = (String) subInfo.get("toc");
+                    bookDetailRes.setPage(itemPage);
+                    bookDetailRes.setToc(toc);
+                }
+            }
+            // BookRes 객체 생성
+            return BookRes.builder()
+                    .item(bookDetailRes)
+                    .build();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new BookRes(); // 오류 발생 시 빈 객체 반환
+        }
+    }
+
+
 
 }

--- a/src/main/java/com/nookbook/domain/book/applicaiton/BookService.java
+++ b/src/main/java/com/nookbook/domain/book/applicaiton/BookService.java
@@ -32,7 +32,7 @@ import java.util.*;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class AladinService {
+public class BookService {
 
     private final UserRepository userRepository;
     private final BookRepository bookRepository;

--- a/src/main/java/com/nookbook/domain/book/domain/Book.java
+++ b/src/main/java/com/nookbook/domain/book/domain/Book.java
@@ -1,0 +1,71 @@
+package com.nookbook.domain.book.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name="Book")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Book {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="book_id", updatable = false, nullable = false, unique = true)
+    private Long bookId;
+
+    @Column(name="title")
+    private String title;
+
+    @Column(name="author")
+    private String author;
+
+    @Column(name="page")
+    private int page;
+
+    @Column(name="isbn", updatable = false, nullable = false, unique = true)
+    private String isbn;
+
+    @Column(name="publishedDate")
+    private LocalDate publishedDate;
+
+    @Column(name="info")
+    private String info;
+
+    @Column(name="idx")
+    private String idx;
+
+    @Column(name="category")
+    private String category;
+
+    @Column(name="image")
+    private String image;
+
+    @Column(name="publisher")
+    private String publisher;
+
+    @Column(name="link")
+    private String link;
+
+    @Builder
+    public Book(String title, String author, int page, String isbn, LocalDate publishedDate, String info, String idx, String category, String image, String publisher, String link) {
+        this.title = title;
+        this.author = author;
+        this.page = page;
+        this.isbn = isbn;
+        this.publishedDate = publishedDate;
+        this.info = info;
+        this.idx = idx;
+        this.category = category;
+        this.image = image;
+        this.publisher = publisher;
+        this.link = link;
+    }
+
+
+}

--- a/src/main/java/com/nookbook/domain/book/domain/Book.java
+++ b/src/main/java/com/nookbook/domain/book/domain/Book.java
@@ -34,9 +34,11 @@ public class Book {
     @Column(name="publishedDate")
     private LocalDate publishedDate;
 
+    @Lob
     @Column(name="info")
     private String info;
 
+    @Lob
     @Column(name="idx")
     private String idx;
 
@@ -46,14 +48,11 @@ public class Book {
     @Column(name="image")
     private String image;
 
-    @Column(name="publisher")
-    private String publisher;
-
     @Column(name="link")
     private String link;
 
     @Builder
-    public Book(String title, String author, int page, String isbn, LocalDate publishedDate, String info, String idx, String category, String image, String publisher, String link) {
+    public Book(String title, String author, int page, String isbn, LocalDate publishedDate, String info, String idx, String category, String image, String link) {
         this.title = title;
         this.author = author;
         this.page = page;
@@ -63,7 +62,6 @@ public class Book {
         this.idx = idx;
         this.category = category;
         this.image = image;
-        this.publisher = publisher;
         this.link = link;
     }
 

--- a/src/main/java/com/nookbook/domain/book/domain/repository/BookRepository.java
+++ b/src/main/java/com/nookbook/domain/book/domain/repository/BookRepository.java
@@ -1,0 +1,12 @@
+package com.nookbook.domain.book.domain.repository;
+
+import com.nookbook.domain.book.domain.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BookRepository extends JpaRepository<Book, Long> {
+    boolean existsByIsbn(String isbn);
+
+    Book findByIsbn(String isbn);
+}

--- a/src/main/java/com/nookbook/domain/book/dto/response/BestSellerBookRes.java
+++ b/src/main/java/com/nookbook/domain/book/dto/response/BestSellerBookRes.java
@@ -1,0 +1,37 @@
+package com.nookbook.domain.book.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BestSellerBookRes {
+
+    @JsonProperty("title")
+    @Schema(type = "String", example = "세이노의 가르침 (100만 부 한정판)", description = "도서의 제목")
+    private String title;
+
+    @JsonProperty("author")
+    @Schema(type = "String", example = "세이노(SayNo) (지은이)", description = "도서의 저자")
+    private String author;
+
+    @JsonProperty("isbn13")
+    @Schema(type = "String", example = "9791168473690", description = "도서의 isbn 13자리")
+    private String isbn13;
+
+    @JsonProperty("cover")
+    @Schema(type = "String", example = "https://image.aladin.co.kr/product/34366/29/coversum/k792932002_1.jpg", description = "도서의 이미지")
+    private String cover;
+
+    @JsonProperty("bestRank")
+    @Schema(type = "int", example = "1", description = "도서의 베스트셀러 순위")
+    private int bestRank;
+}

--- a/src/main/java/com/nookbook/domain/book/dto/response/BestSellerRes.java
+++ b/src/main/java/com/nookbook/domain/book/dto/response/BestSellerRes.java
@@ -1,0 +1,33 @@
+package com.nookbook.domain.book.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BestSellerRes {
+
+    @Schema(type = "int", example = "172", description = "API의 총 결과수")
+    private int totalResults;
+
+    @Schema(type = "int", example = "1", description = "Page 수")
+    private int startIndex;
+
+    @Schema(type = "int", example = "10", description = "한 페이지에 출력될 상품 수")
+    private int itemsPerPage;
+
+    @JsonProperty("item")
+    @Schema(type = "List<BestSellerBookRes>", example = "BestSellerBookRes의 Schemas를 참고해주세요.", description = "검색된 베스트셀러 정보의 리스트")
+    private List<BestSellerBookRes> items;
+
+}

--- a/src/main/java/com/nookbook/domain/book/dto/response/BookDetailRes.java
+++ b/src/main/java/com/nookbook/domain/book/dto/response/BookDetailRes.java
@@ -1,0 +1,64 @@
+package com.nookbook.domain.book.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.nookbook.domain.user_book.domain.BookStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BookDetailRes {
+
+    @JsonProperty("title")
+    @Schema(type = "String", example = "몰입 : 인생을 바꾸는 자기 혁명 - Think Hard!", description = "도서의 제목")
+    private String title;
+
+    @JsonProperty("author")
+    @Schema(type = "String", example = "황농문 (지은이)", description = "도서의 저자")
+    private String author;
+
+    @JsonProperty("cover")
+    @Schema(type = "String", example = "https://image.aladin.co.kr/product/102/9/coversum/s552832633_2.jpg", description = "도서의 이미지")
+    private String cover;
+
+    @JsonProperty("isbn13")
+    @Schema(type = "String", example = "9788925514826", description = "도서의 isbn 13자리")
+    private String isbn13;
+
+    @JsonProperty("pubDate")
+    @Schema(type = "String", example = "2023-03-02", description = "도서의 출판일자")
+    private String pubDate;
+
+    // 페이지
+    @JsonProperty("itemPage")
+    @Schema(type = "int", example = "292", description = "도서의 총 페이지 수")
+    private int page;
+
+    @JsonProperty("fullDescription")
+    @Schema(type = "String", example = "<BR>\\n<BR>\\n몰입전문가 황농문 교수는 바로 '몰입'이 천재성을 일깨워줄 열쇠라고 말한다. 저자는...", description = "도서의 상세 정보")
+    private String description;
+
+    // 목차
+    @JsonProperty("toc")
+    @Schema(type = "String", example = "<p>prologue 몰입, 최고의 나를 만나는 기회<BR>\\nintro 몰입 상태에서 경험한 문제 해결의 순간<BR>...", description = "도서의 목차")
+    private String toc;
+
+    @JsonProperty("link")
+    @Schema(type = "String", example = "http://www.aladin.co.kr/shop/wproduct.aspx?ItemId=1020939&amp;partner=openAPI&amp;start=api", description = "'자세히 보기' 클릭 시 연결되는 알라딘 도서 페이지 링크")
+    private String link;
+
+    public void setToc(String toc) {
+        this.toc = toc;
+    }
+
+    public void setPage(int page) {
+        this.page = page;
+    }
+}

--- a/src/main/java/com/nookbook/domain/book/dto/response/BookDetailRes.java
+++ b/src/main/java/com/nookbook/domain/book/dto/response/BookDetailRes.java
@@ -54,11 +54,25 @@ public class BookDetailRes {
     @Schema(type = "String", example = "http://www.aladin.co.kr/shop/wproduct.aspx?ItemId=1020939&amp;partner=openAPI&amp;start=api", description = "'자세히 보기' 클릭 시 연결되는 알라딘 도서 페이지 링크")
     private String link;
 
+    @JsonProperty("categoryName")
+    @Schema(type = "String", example = "소설/시/희곡", description = "도서의 카테고리입니다.")
+    private String category;
+
+
     public void setToc(String toc) {
         this.toc = toc;
     }
 
     public void setPage(int page) {
         this.page = page;
+    }
+
+    public void formatCategoryName(String categoryName) {
+        String[] parts = categoryName.split(">");
+        if (parts.length > 1) {
+            this.category = parts[1];
+        } else {
+            this.category = "기타";
+        }
     }
 }

--- a/src/main/java/com/nookbook/domain/book/dto/response/BookRes.java
+++ b/src/main/java/com/nookbook/domain/book/dto/response/BookRes.java
@@ -1,0 +1,40 @@
+package com.nookbook.domain.book.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.nookbook.domain.user_book.domain.BookStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BookRes {
+
+    @Schema(type = "String", example = "BEFORE_READING", description = "도서의 읽음 상태. BEFORE_READING(읽기 전), READING(읽는 중)")
+    private BookStatus bookStatus;
+
+    @Schema(type = "boolean", example = "true", description = "도서의 컬렉션 저장 여부")
+    private boolean storedCollection;
+
+    @JsonProperty("item")
+    @Schema(type = "BookDetailRes", example = "BookDetailRes의 Schemas를 참고해주세요.", description = "조회한 도서의 상세 정보")
+    private BookDetailRes item;
+
+    public void setBookStatus(BookStatus bookStatus) {
+        this.bookStatus = bookStatus;
+    }
+
+    public void setStoredCollection(boolean storedCollection) {
+        this.storedCollection = storedCollection;
+    }
+
+}

--- a/src/main/java/com/nookbook/domain/book/dto/response/KeywordRes.java
+++ b/src/main/java/com/nookbook/domain/book/dto/response/KeywordRes.java
@@ -1,5 +1,6 @@
 package com.nookbook.domain.book.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,6 +11,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class KeywordRes {
+
+    @Schema(type = "Long", example = "1", description = "검색어의 고유 id")
     private Long keywordId;
+
+    @Schema(type = "String", example = "세이노", description = "검색어")
     private String content;
 }

--- a/src/main/java/com/nookbook/domain/book/dto/response/KeywordRes.java
+++ b/src/main/java/com/nookbook/domain/book/dto/response/KeywordRes.java
@@ -1,0 +1,15 @@
+package com.nookbook.domain.book.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KeywordRes {
+    private Long keywordId;
+    private String content;
+}

--- a/src/main/java/com/nookbook/domain/book/dto/response/SearchBookRes.java
+++ b/src/main/java/com/nookbook/domain/book/dto/response/SearchBookRes.java
@@ -20,10 +20,6 @@ public class SearchBookRes {
     @Schema(type = "String", example = "세이노의 가르침 (100만 부 한정판)", description = "도서의 제목")
     private String title;
 
-    @JsonProperty("link")
-    @Schema(type = "String", example = "http://www.aladin.co.kr/shop/wproduct.aspx?ItemId=343662988&amp;partner=openAPI&amp;start=api", description = "해당 도서의 알라딘 페이지와 연결되는 주소")
-    private String link;
-
     @JsonProperty("author")
     @Schema(type = "String", example = "세이노(SayNo) (지은이)", description = "도서의 저자")
     private String author;

--- a/src/main/java/com/nookbook/domain/book/dto/response/SearchBookRes.java
+++ b/src/main/java/com/nookbook/domain/book/dto/response/SearchBookRes.java
@@ -1,0 +1,46 @@
+package com.nookbook.domain.book.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SearchBookRes {
+
+    @JsonProperty("title")
+    @Schema(type = "String", example = "세이노의 가르침 (100만 부 한정판)", description = "도서의 제목")
+    private String title;
+
+    @JsonProperty("link")
+    @Schema(type = "String", example = "http://www.aladin.co.kr/shop/wproduct.aspx?ItemId=343662988&amp;partner=openAPI&amp;start=api", description = "해당 도서의 알라딘 페이지와 연결되는 주소")
+    private String link;
+
+    @JsonProperty("author")
+    @Schema(type = "String", example = "세이노(SayNo) (지은이)", description = "도서의 저자")
+    private String author;
+
+    @JsonProperty("pubDate")
+    @Schema(type = "String", example = "2023-03-02", description = "도서의 출판일자")
+    private String pubDate;
+
+    @JsonProperty("isbn13")
+    @Schema(type = "String", example = "9791168473690", description = "도서의 isbn 13자리")
+    private String isbn13;
+
+    @JsonProperty("cover")
+    @Schema(type = "String", example = "https://image.aladin.co.kr/product/34366/29/coversum/k792932002_1.jpg", description = "도서의 이미지")
+    private String cover;
+
+    @JsonProperty("publisher")
+    @Schema(type = "String", example = "데이원", description = "도서의 출판사")
+    private String publisher;
+}

--- a/src/main/java/com/nookbook/domain/book/dto/response/SearchRes.java
+++ b/src/main/java/com/nookbook/domain/book/dto/response/SearchRes.java
@@ -1,0 +1,32 @@
+package com.nookbook.domain.book.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SearchRes {
+
+    @Schema(type = "int", example = "172", description = "API의 총 결과수")
+    private int totalResults;
+
+    @Schema(type = "int", example = "1", description = "Page 수")
+    private int startIndex;
+
+    @Schema(type = "int", example = "10", description = "한 페이지에 출력될 상품 수")
+    private int itemsPerPage;
+
+    @JsonProperty("item")
+    @Schema(type = "List<SearchBookRes>", example = "SearchBookRes의 Schemas를 참고해주세요.", description = "검색된 상품 정보의 리스트")
+    private List<SearchBookRes> items;
+}

--- a/src/main/java/com/nookbook/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nookbook/domain/book/presentation/BookController.java
@@ -1,6 +1,7 @@
 package com.nookbook.domain.book.presentation;
 
 import com.nookbook.domain.book.applicaiton.AladinService;
+import com.nookbook.domain.book.dto.response.BestSellerRes;
 import com.nookbook.domain.book.dto.response.KeywordRes;
 import com.nookbook.domain.book.dto.response.SearchRes;
 import com.nookbook.domain.keyword.application.KeywordService;
@@ -42,6 +43,19 @@ public class BookController {
             @Parameter(description = "검색된 도서 목록을 페이지별로 조회합니다. **Page는 1부터 시작합니다!**", required = true) @RequestParam(defaultValue = "1") int page
             ) {
         return aladinService.searchBooks(userPrincipal, keyword, page);
+    }
+
+    @Operation(summary = "베스트셀러 조회", description = "베스트셀러를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "검색 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = BestSellerRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "검색 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    } )
+    @GetMapping("/best-seller")
+    public ResponseEntity<?> findBestSellers(
+            //@Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "베스트셀러를 페이지별로 조회합니다. **Page는 1부터 시작합니다!**", required = true) @RequestParam(defaultValue = "1") int page
+    ) {
+        return aladinService.getBestSeller(page);
     }
 
     @Operation(summary = "검색어 조회", description = "사용자의 검색어를 최대 5개 조회합니다.")

--- a/src/main/java/com/nookbook/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nookbook/domain/book/presentation/BookController.java
@@ -1,0 +1,44 @@
+package com.nookbook.domain.book.presentation;
+
+import com.nookbook.domain.book.applicaiton.AladinService;
+import com.nookbook.domain.book.dto.response.SearchRes;
+import com.nookbook.domain.user.dto.request.UserInfoReq;
+import com.nookbook.global.config.security.token.CurrentUser;
+import com.nookbook.global.config.security.token.UserPrincipal;
+import com.nookbook.global.payload.ErrorResponse;
+import com.nookbook.global.payload.Message;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Book", description = "Book API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/book")
+public class BookController {
+
+    private final AladinService aladinService;
+
+    @Operation(summary = "도서 검색", description = "도서를 제목, 저자, 출판사로 검색합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "검색 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = SearchRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "검색 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    } )
+    @GetMapping("/search")
+    public ResponseEntity<?> findBooksByKeyword(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "검색어를 입력해주세요.", required = true) @RequestParam String keyword,
+            @Parameter(description = "검색된 도서 목록을 페이지별로 조회합니다. **Page는 1부터 시작합니다!**", required = true) @RequestParam(defaultValue = "1") int page
+            ) {
+        return aladinService.searchBooks(keyword, page);
+    }
+
+}

--- a/src/main/java/com/nookbook/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nookbook/domain/book/presentation/BookController.java
@@ -1,7 +1,9 @@
 package com.nookbook.domain.book.presentation;
 
 import com.nookbook.domain.book.applicaiton.AladinService;
+import com.nookbook.domain.book.dto.response.KeywordRes;
 import com.nookbook.domain.book.dto.response.SearchRes;
+import com.nookbook.domain.keyword.application.KeywordService;
 import com.nookbook.domain.user.dto.request.UserInfoReq;
 import com.nookbook.global.config.security.token.CurrentUser;
 import com.nookbook.global.config.security.token.UserPrincipal;
@@ -26,6 +28,7 @@ import org.springframework.web.bind.annotation.*;
 public class BookController {
 
     private final AladinService aladinService;
+    private final KeywordService keywordService;
 
     @Operation(summary = "도서 검색", description = "도서를 제목, 저자, 출판사로 검색합니다.")
     @ApiResponses(value = {
@@ -39,6 +42,31 @@ public class BookController {
             @Parameter(description = "검색된 도서 목록을 페이지별로 조회합니다. **Page는 1부터 시작합니다!**", required = true) @RequestParam(defaultValue = "1") int page
             ) {
         return aladinService.searchBooks(userPrincipal, keyword, page);
+    }
+
+    @Operation(summary = "검색어 조회", description = "사용자의 검색어를 최대 5개 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = KeywordRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    } )
+    @GetMapping("/keyword")
+    public ResponseEntity<?> findKeywords(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal
+    ) {
+        return keywordService.getKeywords(userPrincipal);
+    }
+
+    @Operation(summary = "검색어 삭제", description = "사용자의 검색어를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "검색 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = SearchRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "검색 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    } )
+    @DeleteMapping("/keyword/{keywordId}")
+    public ResponseEntity<?> deleteKeyword(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "검색어의 id를 입력해주세요.", required = true) @PathVariable Long keywordId
+    ) {
+        return keywordService.deleteKeyword(userPrincipal, keywordId);
     }
 
 }

--- a/src/main/java/com/nookbook/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nookbook/domain/book/presentation/BookController.java
@@ -2,6 +2,7 @@ package com.nookbook.domain.book.presentation;
 
 import com.nookbook.domain.book.applicaiton.AladinService;
 import com.nookbook.domain.book.dto.response.BestSellerRes;
+import com.nookbook.domain.book.dto.response.BookDetailRes;
 import com.nookbook.domain.book.dto.response.KeywordRes;
 import com.nookbook.domain.book.dto.response.SearchRes;
 import com.nookbook.domain.keyword.application.KeywordService;
@@ -45,6 +46,19 @@ public class BookController {
         return aladinService.searchBooks(userPrincipal, keyword, page);
     }
 
+    @Operation(summary = "도서 상세 조회", description = "도서를 상세 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = BookDetailRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    } )
+    @GetMapping
+    public ResponseEntity<?> findBookDetail(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "조회하려는 도서의 isbn을 입력해주세요.", required = true) @RequestParam String isbn
+    ) {
+        return aladinService.getBookDetail(userPrincipal, isbn);
+    }
+
     @Operation(summary = "베스트셀러 조회", description = "베스트셀러를 카테고리별로 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "검색 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = BestSellerRes.class) ) } ),
@@ -60,6 +74,8 @@ public class BookController {
         return aladinService.getBestSellerByCategory(page, category, size);
     }
 
+
+    // 검색어 관련
     @Operation(summary = "검색어 조회", description = "사용자의 검색어를 최대 5개 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = KeywordRes.class) ) } ),

--- a/src/main/java/com/nookbook/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nookbook/domain/book/presentation/BookController.java
@@ -56,6 +56,19 @@ public class BookController {
         return bookService.getBookDetail(userPrincipal, isbn);
     }
 
+    @Operation(summary = "도서 상태 변경", description = "도서의 읽음 상태를 변경합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "변경 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "변경 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    } )
+    @PatchMapping
+    public ResponseEntity<?> updateBookStatus(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "상태를 변경하려는 도서의 isbn을 입력해주세요.", required = true) @RequestParam String isbn
+    ) {
+        return bookService.updateBookStatus(userPrincipal, isbn);
+    }
+
     @Operation(summary = "베스트셀러 조회", description = "베스트셀러를 카테고리별로 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "검색 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = BestSellerRes.class) ) } ),

--- a/src/main/java/com/nookbook/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nookbook/domain/book/presentation/BookController.java
@@ -45,17 +45,19 @@ public class BookController {
         return aladinService.searchBooks(userPrincipal, keyword, page);
     }
 
-    @Operation(summary = "베스트셀러 조회", description = "베스트셀러를 조회합니다.")
+    @Operation(summary = "베스트셀러 조회", description = "베스트셀러를 카테고리별로 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "검색 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = BestSellerRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "검색 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     } )
     @GetMapping("/best-seller")
     public ResponseEntity<?> findBestSellers(
-            //@Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "베스트셀러의 카테고리를 입력해주세요. 종합(0), 소설(1), 경제/경영(170), 자기계발(336), 시(50940), 에세이(55889), 인문/교양(656), 취미/실용(55890), 매거진(2913), 기본값은 종합(0)입니다.", required = true) @RequestParam(defaultValue = "0") int category,
+            @Parameter(description = "page의 size입니다. 기본 값은 size입니다.", required = true) @RequestParam(defaultValue = "20") int size,
             @Parameter(description = "베스트셀러를 페이지별로 조회합니다. **Page는 1부터 시작합니다!**", required = true) @RequestParam(defaultValue = "1") int page
     ) {
-        return aladinService.getBestSeller(page);
+        return aladinService.getBestSellerByCategory(page, category, size);
     }
 
     @Operation(summary = "검색어 조회", description = "사용자의 검색어를 최대 5개 조회합니다.")

--- a/src/main/java/com/nookbook/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nookbook/domain/book/presentation/BookController.java
@@ -1,16 +1,14 @@
 package com.nookbook.domain.book.presentation;
 
-import com.nookbook.domain.book.applicaiton.AladinService;
+import com.nookbook.domain.book.applicaiton.BookService;
 import com.nookbook.domain.book.dto.response.BestSellerRes;
 import com.nookbook.domain.book.dto.response.BookDetailRes;
 import com.nookbook.domain.book.dto.response.KeywordRes;
 import com.nookbook.domain.book.dto.response.SearchRes;
 import com.nookbook.domain.keyword.application.KeywordService;
-import com.nookbook.domain.user.dto.request.UserInfoReq;
 import com.nookbook.global.config.security.token.CurrentUser;
 import com.nookbook.global.config.security.token.UserPrincipal;
 import com.nookbook.global.payload.ErrorResponse;
-import com.nookbook.global.payload.Message;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -18,7 +16,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -29,7 +26,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/book")
 public class BookController {
 
-    private final AladinService aladinService;
+    private final BookService bookService;
     private final KeywordService keywordService;
 
     @Operation(summary = "도서 검색", description = "도서를 제목, 저자, 출판사로 검색합니다.")
@@ -43,7 +40,7 @@ public class BookController {
             @Parameter(description = "검색어를 입력해주세요.", required = true) @RequestParam String keyword,
             @Parameter(description = "검색된 도서 목록을 페이지별로 조회합니다. **Page는 1부터 시작합니다!**", required = true) @RequestParam(defaultValue = "1") int page
             ) {
-        return aladinService.searchBooks(userPrincipal, keyword, page);
+        return bookService.searchBooks(userPrincipal, keyword, page);
     }
 
     @Operation(summary = "도서 상세 조회", description = "도서를 상세 조회합니다.")
@@ -56,7 +53,7 @@ public class BookController {
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "조회하려는 도서의 isbn을 입력해주세요.", required = true) @RequestParam String isbn
     ) {
-        return aladinService.getBookDetail(userPrincipal, isbn);
+        return bookService.getBookDetail(userPrincipal, isbn);
     }
 
     @Operation(summary = "베스트셀러 조회", description = "베스트셀러를 카테고리별로 조회합니다.")
@@ -71,7 +68,7 @@ public class BookController {
             @Parameter(description = "page의 size입니다. 기본 값은 size입니다.", required = true) @RequestParam(defaultValue = "20") int size,
             @Parameter(description = "베스트셀러를 페이지별로 조회합니다. **Page는 1부터 시작합니다!**", required = true) @RequestParam(defaultValue = "1") int page
     ) {
-        return aladinService.getBestSellerByCategory(page, category, size);
+        return bookService.getBestSellerByCategory(page, category, size);
     }
 
 

--- a/src/main/java/com/nookbook/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nookbook/domain/book/presentation/BookController.java
@@ -38,7 +38,7 @@ public class BookController {
             @Parameter(description = "검색어를 입력해주세요.", required = true) @RequestParam String keyword,
             @Parameter(description = "검색된 도서 목록을 페이지별로 조회합니다. **Page는 1부터 시작합니다!**", required = true) @RequestParam(defaultValue = "1") int page
             ) {
-        return aladinService.searchBooks(keyword, page);
+        return aladinService.searchBooks(userPrincipal, keyword, page);
     }
 
 }

--- a/src/main/java/com/nookbook/domain/keyword/application/KeywordService.java
+++ b/src/main/java/com/nookbook/domain/keyword/application/KeywordService.java
@@ -1,0 +1,48 @@
+package com.nookbook.domain.keyword.application;
+
+import com.nookbook.domain.keyword.domain.Keyword;
+import com.nookbook.domain.keyword.domain.repository.KeywordRepository;
+import com.nookbook.domain.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class KeywordService {
+
+    private final KeywordRepository keywordRepository;
+
+    @Transactional
+    public void saveKeyword(User user, String keyword) {
+        // 중복되는 키워드가 있을 경우 삭제
+        if (keywordRepository.existsByUserAndContent(user, keyword)) {
+            Keyword targetKeyword = keywordRepository.findByUserAndContent(user, keyword);
+            keywordRepository.delete(targetKeyword);
+        }
+
+        // 새로운 키워드를 저장
+        Keyword newKeyword = Keyword.builder()
+                .content(keyword)
+                .user(user)
+                .build();
+        keywordRepository.save(newKeyword);
+
+        // 키워드 수를 다시 계산하여 5개 초과 시 가장 오래된 키워드 삭제
+        List<Keyword> keywords = keywordRepository.findByUser(user);
+        if (keywords.size() > 5) {
+            Keyword oldestKeyword = keywordRepository.findFirstByUserOrderByCreatedAtAsc(user);
+            if (oldestKeyword != null) {
+                keywordRepository.delete(oldestKeyword);
+            }
+        }
+    }
+
+    // 키워드 조회
+
+    // 키워드 삭제
+}

--- a/src/main/java/com/nookbook/domain/keyword/application/KeywordService.java
+++ b/src/main/java/com/nookbook/domain/keyword/application/KeywordService.java
@@ -1,14 +1,24 @@
 package com.nookbook.domain.keyword.application;
 
+import com.nookbook.domain.book.dto.response.KeywordRes;
 import com.nookbook.domain.keyword.domain.Keyword;
 import com.nookbook.domain.keyword.domain.repository.KeywordRepository;
 import com.nookbook.domain.user.domain.User;
+import com.nookbook.domain.user.domain.repository.UserRepository;
+import com.nookbook.global.DefaultAssert;
+import com.nookbook.global.config.security.token.UserPrincipal;
+import com.nookbook.global.payload.ApiResponse;
+import com.nookbook.global.payload.Message;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +26,7 @@ import java.util.List;
 public class KeywordService {
 
     private final KeywordRepository keywordRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public void saveKeyword(User user, String keyword) {
@@ -24,7 +35,6 @@ public class KeywordService {
             Keyword targetKeyword = keywordRepository.findByUserAndContent(user, keyword);
             keywordRepository.delete(targetKeyword);
         }
-
         // 새로운 키워드를 저장
         Keyword newKeyword = Keyword.builder()
                 .content(keyword)
@@ -43,6 +53,41 @@ public class KeywordService {
     }
 
     // 키워드 조회
+    public ResponseEntity<?> getKeywords(UserPrincipal userPrincipal) {
+        User user = validUserById(userPrincipal.getId());
+        List<Keyword> findKeywords = keywordRepository.findByUser(user);
+        findKeywords.sort(Comparator.comparing(Keyword::getCreatedAt));
+
+        List<KeywordRes> keywords = findKeywords.stream()
+                .map(keyword -> new KeywordRes(keyword.getKeywordId(), keyword.getContent()))
+                .collect(Collectors.toList());
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(keywords)
+                .build();
+        return ResponseEntity.ok(apiResponse);
+    }
 
     // 키워드 삭제
+    @Transactional
+    public ResponseEntity<?> deleteKeyword(UserPrincipal userPrincipal, Long keywordId) {
+        User user = validUserById(userPrincipal.getId());
+        Keyword findKeyword = keywordRepository.findByUserAndKeywordId(user, keywordId);
+
+        DefaultAssert.isTrue(user == findKeyword.getUser(), "해당 검색어에 대한 권한이 없습니다.");
+        keywordRepository.delete(findKeyword);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(Message.builder().message("검색어가 삭제되었습니다.").build())
+                .build();
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    private User validUserById(Long userId) {
+        Optional<User> userOptional = userRepository.findById(userId);
+        DefaultAssert.isTrue(userOptional.isPresent(), "유효한 사용자가 아닙니다.");
+        return userOptional.get();
+    }
 }

--- a/src/main/java/com/nookbook/domain/keyword/domain/Keyword.java
+++ b/src/main/java/com/nookbook/domain/keyword/domain/Keyword.java
@@ -1,0 +1,33 @@
+package com.nookbook.domain.keyword.domain;
+
+import com.nookbook.domain.common.BaseEntity;
+import com.nookbook.domain.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="Keyword")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Keyword extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="keyword_id", updatable = false, nullable = false, unique = true)
+    private Long keywordId;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder
+    public Keyword(String content, User user) {
+        this.content = content;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/nookbook/domain/keyword/domain/repository/KeywordRepository.java
+++ b/src/main/java/com/nookbook/domain/keyword/domain/repository/KeywordRepository.java
@@ -15,4 +15,6 @@ public interface KeywordRepository extends JpaRepository<Keyword, Long> {
     Keyword findFirstByUserOrderByCreatedAtAsc(User user);
 
     Keyword findByUserAndContent(User user, String keyword);
+
+    Keyword findByUserAndKeywordId(User user, Long keywordId);
 }

--- a/src/main/java/com/nookbook/domain/keyword/domain/repository/KeywordRepository.java
+++ b/src/main/java/com/nookbook/domain/keyword/domain/repository/KeywordRepository.java
@@ -1,0 +1,18 @@
+package com.nookbook.domain.keyword.domain.repository;
+
+import com.nookbook.domain.keyword.domain.Keyword;
+import com.nookbook.domain.user.domain.User;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+    List<Keyword> findByUser(User user);
+
+    boolean existsByUserAndContent(User user, String keyword);
+
+    Keyword findFirstByUserOrderByCreatedAtAsc(User user);
+
+    Keyword findByUserAndContent(User user, String keyword);
+}

--- a/src/main/java/com/nookbook/domain/user_book/domain/BookStatus.java
+++ b/src/main/java/com/nookbook/domain/user_book/domain/BookStatus.java
@@ -1,0 +1,8 @@
+package com.nookbook.domain.user_book.domain;
+
+public enum BookStatus {
+
+    BEFORE_READING,
+    READING
+
+}

--- a/src/main/java/com/nookbook/domain/user_book/domain/UserBook.java
+++ b/src/main/java/com/nookbook/domain/user_book/domain/UserBook.java
@@ -1,0 +1,39 @@
+package com.nookbook.domain.user_book.domain;
+
+import com.nookbook.domain.book.domain.Book;
+import com.nookbook.domain.user.domain.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="User_Book")
+@NoArgsConstructor
+@Getter
+public class UserBook {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="user_book_id", updatable = false, nullable = false, unique = true)
+    private Long userBookId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id")
+    private Book book;
+
+    @Enumerated(EnumType.STRING)
+    private BookStatus bookStatus = BookStatus.BEFORE_READING;
+
+    @Builder
+    public UserBook(User user, Book book) {
+        this.user = user;
+        this.book = book;
+    }
+
+    public void updateBookStatus(BookStatus bookStatus) { this.bookStatus = bookStatus; }
+}

--- a/src/main/java/com/nookbook/domain/user_book/domain/UserBook.java
+++ b/src/main/java/com/nookbook/domain/user_book/domain/UserBook.java
@@ -30,9 +30,10 @@ public class UserBook {
     private BookStatus bookStatus = BookStatus.BEFORE_READING;
 
     @Builder
-    public UserBook(User user, Book book) {
+    public UserBook(User user, Book book, BookStatus bookStatus) {
         this.user = user;
         this.book = book;
+        this.bookStatus = bookStatus;
     }
 
     public void updateBookStatus(BookStatus bookStatus) { this.bookStatus = bookStatus; }

--- a/src/main/java/com/nookbook/domain/user_book/domain/repository/UserBookRepository.java
+++ b/src/main/java/com/nookbook/domain/user_book/domain/repository/UserBookRepository.java
@@ -1,0 +1,14 @@
+package com.nookbook.domain.user_book.domain.repository;
+
+import com.nookbook.domain.book.domain.Book;
+import com.nookbook.domain.user.domain.User;
+import com.nookbook.domain.user_book.domain.UserBook;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserBookRepository extends JpaRepository<UserBook, Long> {
+    Optional<UserBook> findByUserAndBook(User user, Book book);
+}


### PR DESCRIPTION
## 👑 Summary
> 어떤 내용의 PR인가요?
- 도서 관련 API 구현

## 🫧 To be noted
> PR을 검토할 때 확인해야 할 사항이 있나요?
- 조금 로직이 복잡합니다🥲내부 로직 중 설명드려야 할 부분은
    - 도서 검색 시: 검색어 저장(5개 제한)
    - 도서 읽음 상태 변경 시: 도서 DB에 저장 후 `userBook`과 연결
- `book`, `user_book` 엔티티 구현했고, `book`에서는 기존 ERD와 다르게 `link` 추가, `publisher` 삭제했습니다
++ `index`가 예약어라 `idx`로 변경했습니다!
- `keyword` 엔티티를 추가했는데, 검색어 저장을 위함입니다
- 테스트해보니 `info`, `idx`가 `String`일 때 `Data too long` 오류가 발생해 `Text` 타입으로 바꿔두었습니다🥰

## 💫 issue number
> 이슈 번호를 작성해주새요
- closes #9 

## ☑️ Checklist
> PR 요청 시 체크해주세요.
- [ ] label
- [ ] issue number
- [ ] conflict resolve

## 💡 Comment
> 전달하고 싶은 내용이 있나요?
- 알라딘 연결을 위해 `application-book.yml` 추가했습니다(노션에 기재해두었습니다!)
- 상세 조회 시 컬렉션 저장 여부를 확인해야 할 것 같은데, 컬렉션 구현이 완료되면 수정해두겠습니다