### PR TITLE
[FEAT] 타이머 관련 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,13 +56,6 @@ dependencies {
     // AWS S3
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 
-    // Google Vision
-    implementation 'com.google.cloud:google-cloud-vision:3.34.0'
-
-    // gcp storage
-    implementation 'org.springframework.cloud:spring-cloud-gcp-starter:1.2.8.RELEASE'
-    implementation 'org.springframework.cloud:spring-cloud-gcp-storage:1.2.8.RELEASE'
-
 }
 
 tasks.named('test') {

--- a/src/main/java/com/nookbook/domain/book/applicaiton/BookService.java
+++ b/src/main/java/com/nookbook/domain/book/applicaiton/BookService.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nookbook.domain.book.domain.Book;
 import com.nookbook.domain.book.domain.repository.BookRepository;
 import com.nookbook.domain.book.dto.response.*;
-import com.nookbook.domain.collection.domain.Collection;
 import com.nookbook.domain.collection.domain.CollectionBook;
 import com.nookbook.domain.collection.domain.repository.CollectionBookRepository;
 import com.nookbook.domain.keyword.application.KeywordService;
@@ -265,16 +264,13 @@ public class BookService {
         try {
             // JSON 문자열을 Map 형태로 변환
             Map<String, Object> map = objectMapper.readValue(json, new TypeReference<>() {});
-
             // "item" 배열을 추출
             List<Map<String, Object>> items = (List<Map<String, Object>>) map.get("item");
-
             // 첫 번째 아이템을 BookDetailRes로 변환
             BookDetailRes bookDetailRes = null;
             if (items != null && !items.isEmpty()) {
                 Map<String, Object> item = items.get(0);
                 bookDetailRes = objectMapper.convertValue(item, BookDetailRes.class);
-
                 // subInfo를 추출하고 itemPage 값을 설정
                 Map<String, Object> subInfo = (Map<String, Object>) item.get("subInfo");
                 if (subInfo != null) {
@@ -287,7 +283,6 @@ public class BookService {
             }
             // BookDetailRes 객체 반환
             return bookDetailRes;
-
         } catch (Exception e) {
             System.err.println("Error converting JSON to BookRes: " + e.getMessage());
             e.printStackTrace();

--- a/src/main/java/com/nookbook/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nookbook/domain/book/presentation/BookController.java
@@ -3,6 +3,9 @@ package com.nookbook.domain.book.presentation;
 import com.nookbook.domain.book.applicaiton.BookService;
 import com.nookbook.domain.book.dto.response.*;
 import com.nookbook.domain.keyword.application.KeywordService;
+import com.nookbook.domain.timer.application.TimerService;
+import com.nookbook.domain.timer.dto.request.CreateTimerReq;
+import com.nookbook.domain.timer.dto.response.TimerRes;
 import com.nookbook.domain.user_book.domain.BookStatus;
 import com.nookbook.global.config.security.token.CurrentUser;
 import com.nookbook.global.config.security.token.UserPrincipal;
@@ -20,6 +23,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalTime;
+
 @Tag(name = "Book", description = "Book API")
 @RestController
 @RequiredArgsConstructor
@@ -28,6 +33,7 @@ public class BookController {
 
     private final BookService bookService;
     private final KeywordService keywordService;
+    private final TimerService timerService;
 
     @Operation(summary = "도서 검색", description = "도서를 제목, 저자, 출판사로 검색합니다.")
     @ApiResponses(value = {
@@ -111,4 +117,30 @@ public class BookController {
         return keywordService.deleteKeyword(userPrincipal, keywordId);
     }
 
+    @Operation(summary = "타이머 기록 조회", description = "타이머 기록의 누적 시간 및 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = TimerRes.class)) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    } )
+    @GetMapping("/{bookId}/timer")
+    public ResponseEntity<?> getTimerRecord(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "도서의 id를 입력해주세요.", required = true) @PathVariable Long bookId
+    ) {
+        return timerService.getTimerRecords(userPrincipal, bookId);
+    }
+
+    @Operation(summary = "타이머 기록 저장", description = "타이머 기록을 저장합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = TimerRes.class)) } ),
+            @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    } )
+    @PostMapping("/{bookId}/timer")
+    public ResponseEntity<?> saveTimerRecord(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "도서의 id를 입력해주세요.", required = true) @PathVariable Long bookId,
+            @Parameter(description = "시간을 입력해주세요.", required = true) @RequestBody CreateTimerReq createTimerReq
+            ) {
+        return timerService.saveTimerRecord(userPrincipal, bookId, createTimerReq);
+    }
 }

--- a/src/main/java/com/nookbook/domain/timer/application/TimerService.java
+++ b/src/main/java/com/nookbook/domain/timer/application/TimerService.java
@@ -93,7 +93,7 @@ public class TimerService {
         List<TimerRecordRes> timerRecordRes = timerList.stream()
                 .map(timer -> TimerRecordRes.builder()
                         .timerId(timer.getTimerId())
-                        .date(timer.getCreatedAt().toLocalDate())
+                        .date(timer.getCreatedAt())
                         .readTime(convertBigIntegerToString(timer.getReadTime()))
                         .build())
                 .toList();

--- a/src/main/java/com/nookbook/domain/timer/application/TimerService.java
+++ b/src/main/java/com/nookbook/domain/timer/application/TimerService.java
@@ -1,0 +1,124 @@
+package com.nookbook.domain.timer.application;
+
+import com.nookbook.domain.book.domain.Book;
+import com.nookbook.domain.book.domain.repository.BookRepository;
+import com.nookbook.domain.timer.domain.Timer;
+import com.nookbook.domain.timer.domain.repository.TimerRepository;
+import com.nookbook.domain.timer.dto.request.CreateTimerReq;
+import com.nookbook.domain.timer.dto.response.TimerRecordRes;
+import com.nookbook.domain.timer.dto.response.TimerRes;
+import com.nookbook.domain.user.domain.User;
+import com.nookbook.domain.user.domain.repository.UserRepository;
+import com.nookbook.domain.user_book.domain.BookStatus;
+import com.nookbook.domain.user_book.domain.UserBook;
+import com.nookbook.domain.user_book.domain.repository.UserBookRepository;
+import com.nookbook.global.DefaultAssert;
+import com.nookbook.global.config.security.token.UserPrincipal;
+import com.nookbook.global.payload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TimerService {
+
+    private final UserRepository userRepository;
+    private final UserBookRepository userBookRepository;
+    private final BookRepository bookRepository;
+    private final TimerRepository timerRepository;
+
+    // 타이머 저장
+    @Transactional
+    public ResponseEntity<?> saveTimerRecord(UserPrincipal userPrincipal, Long bookId, CreateTimerReq createTimerReq) {
+        User user = validUserById(1L);
+        Book book = validBookById(bookId);
+        Optional<UserBook> userBookOptional = userBookRepository.findByUserAndBook(user, book);
+        UserBook userBook = userBookOptional.get();
+        plusTotalReadTime(userBook, userBook.getTotalReadTime(), createTimerReq.getTime());
+        if (timerRepository.countByUserBook(userBook) >= 5) {
+            Timer oldestTimer = timerRepository.findTop1ByUserBookOrderByCreatedAtAsc(userBook);
+            timerRepository.delete(oldestTimer);
+        }
+        Timer timer = Timer.builder()
+                .userBook(userBook)
+                .readTime(createTimerReq.getTime())
+                .build();
+        timerRepository.save(timer);
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information("타이머가 저장되었습니다.")
+                .build();
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    private void plusTotalReadTime(UserBook userBook, BigInteger totalTime, BigInteger additionalTime) {
+        BigInteger combinedTime = totalTime.add(additionalTime);
+        userBook.updateTotalReadTime(combinedTime);
+    }
+
+    private String convertBigIntegerToString(BigInteger time) {
+        long totalSeconds = time.longValue();
+        long hours = totalSeconds / 3600;
+        long minutes = (totalSeconds % 3600) / 60;
+        long seconds = totalSeconds % 60;
+        // "HH:mm:ss" 형식으로 반환
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    }
+
+    // 타이머 조회
+    @Transactional
+    public ResponseEntity<?> getTimerRecords(UserPrincipal userPrincipal, Long bookId) {
+        User user = validUserById(1L);
+        Book book = validBookById(bookId);
+        Optional<UserBook> userBookOptional = userBookRepository.findByUserAndBook(user, book);
+        UserBook userBook;
+        if (userBookOptional.isEmpty()) {
+            userBook = UserBook.builder()
+                    .user(user)
+                    .book(book)
+                    .bookStatus(BookStatus.BEFORE_READ)
+                    .build();
+            userBookRepository.save(userBook);
+        } else {
+            userBook = userBookOptional.get();
+        }
+        List<Timer> timerList = timerRepository.findByUserBookOrderByCreatedAtDesc(userBook);
+        List<TimerRecordRes> timerRecordRes = timerList.stream()
+                .map(timer -> TimerRecordRes.builder()
+                        .timerId(timer.getTimerId())
+                        .date(timer.getCreatedAt().toLocalDate())
+                        .readTime(convertBigIntegerToString(timer.getReadTime()))
+                        .build())
+                .toList();
+        TimerRes timerRes = TimerRes.builder()
+                .totalReadTime(convertBigIntegerToString(userBook.getTotalReadTime()))
+                .recordResList(timerRecordRes)
+                .build();
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(timerRes)
+                .build();
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    private Book validBookById(Long bookId) {
+        Optional<Book> bookOptional = bookRepository.findById(bookId);
+        DefaultAssert.isTrue(bookOptional.isPresent(), "해당 책이 존재하지 않습니다.");
+        return bookOptional.get();
+    }
+
+    private User validUserById(Long userId) {
+        // Optional<User> userOptional = userRepository.findById(userId);
+        Optional<User> userOptional = userRepository.findById(1L);
+        DefaultAssert.isTrue(userOptional.isPresent(), "유효한 사용자가 아닙니다.");
+        return userOptional.get();
+    }
+
+}

--- a/src/main/java/com/nookbook/domain/timer/application/TimerService.java
+++ b/src/main/java/com/nookbook/domain/timer/application/TimerService.java
@@ -42,7 +42,7 @@ public class TimerService {
         Optional<UserBook> userBookOptional = userBookRepository.findByUserAndBook(user, book);
         UserBook userBook = userBookOptional.get();
         plusTotalReadTime(userBook, userBook.getTotalReadTime(), createTimerReq.getTime());
-        if (timerRepository.countByUserBook(userBook) >= 5) {
+        if (timerRepository.countByUserBook(userBook) >= 10) {
             Timer oldestTimer = timerRepository.findTop1ByUserBookOrderByCreatedAtAsc(userBook);
             timerRepository.delete(oldestTimer);
         }

--- a/src/main/java/com/nookbook/domain/timer/domain/Timer.java
+++ b/src/main/java/com/nookbook/domain/timer/domain/Timer.java
@@ -1,7 +1,6 @@
 package com.nookbook.domain.timer.domain;
 
 import com.nookbook.domain.common.BaseEntity;
-import com.nookbook.domain.user.domain.User;
 import com.nookbook.domain.user_book.domain.UserBook;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -9,8 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigInteger;
-import java.time.Duration;
-import java.time.LocalTime;
 
 @Entity
 @Table(name="Timer")

--- a/src/main/java/com/nookbook/domain/timer/domain/Timer.java
+++ b/src/main/java/com/nookbook/domain/timer/domain/Timer.java
@@ -1,0 +1,38 @@
+package com.nookbook.domain.timer.domain;
+
+import com.nookbook.domain.common.BaseEntity;
+import com.nookbook.domain.user.domain.User;
+import com.nookbook.domain.user_book.domain.UserBook;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigInteger;
+import java.time.Duration;
+import java.time.LocalTime;
+
+@Entity
+@Table(name="Timer")
+@NoArgsConstructor
+@Getter
+public class Timer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="timer_id", updatable = false, nullable = false, unique = true)
+    private Long timerId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_book_id")
+    private UserBook userBook;
+
+    private BigInteger readTime;
+
+    @Builder
+    public Timer(UserBook userBook, BigInteger readTime) {
+        this.userBook = userBook;
+        this.readTime = readTime;
+    }
+
+}

--- a/src/main/java/com/nookbook/domain/timer/domain/repository/TimerRepository.java
+++ b/src/main/java/com/nookbook/domain/timer/domain/repository/TimerRepository.java
@@ -1,0 +1,17 @@
+package com.nookbook.domain.timer.domain.repository;
+
+import com.nookbook.domain.timer.domain.Timer;
+import com.nookbook.domain.user_book.domain.UserBook;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TimerRepository extends JpaRepository<Timer, Long> {
+    int countByUserBook(UserBook userBook);
+
+    Timer findTop1ByUserBookOrderByCreatedAtAsc(UserBook userBook);
+
+    List<Timer> findByUserBookOrderByCreatedAtDesc(UserBook userBook);
+}

--- a/src/main/java/com/nookbook/domain/timer/dto/request/CreateTimerReq.java
+++ b/src/main/java/com/nookbook/domain/timer/dto/request/CreateTimerReq.java
@@ -8,6 +8,6 @@ import java.math.BigInteger;
 @Getter
 public class CreateTimerReq {
 
-    @Schema(type = "BigInteger", example = "3200000", description = "특정 도서의 누적 독서 시간입니다. 초단위로 전달해주세요.")
+    @Schema(type = "BigInteger", example = "48000", description = "특정 도서의 타이머 독서 시간입니다. 초단위로 전달해주세요.")
     private BigInteger time;
 }

--- a/src/main/java/com/nookbook/domain/timer/dto/request/CreateTimerReq.java
+++ b/src/main/java/com/nookbook/domain/timer/dto/request/CreateTimerReq.java
@@ -1,0 +1,13 @@
+package com.nookbook.domain.timer.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.math.BigInteger;
+
+@Getter
+public class CreateTimerReq {
+
+    @Schema(type = "BigInteger", example = "3200000", description = "특정 도서의 누적 독서 시간입니다. 초단위로 전달해주세요.")
+    private BigInteger time;
+}

--- a/src/main/java/com/nookbook/domain/timer/dto/response/TimerRecordRes.java
+++ b/src/main/java/com/nookbook/domain/timer/dto/response/TimerRecordRes.java
@@ -1,0 +1,26 @@
+package com.nookbook.domain.timer.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimerRecordRes {
+
+    @Schema(type = "Long", example = "1", description = "독서 시간의 id")
+    public Long timerId;
+
+    @Schema(type = "LocalDate", example = "2025-01-21", description = "타이머를 시작한 일시입니다.")
+    public LocalDate date;
+
+    @Schema(type = "String", example = "01:20:00", description = "독서 시간입니다. HH:MM:SS 형식입니다.")
+    public String readTime;
+}

--- a/src/main/java/com/nookbook/domain/timer/dto/response/TimerRecordRes.java
+++ b/src/main/java/com/nookbook/domain/timer/dto/response/TimerRecordRes.java
@@ -6,8 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -15,11 +14,11 @@ import java.time.LocalTime;
 @AllArgsConstructor
 public class TimerRecordRes {
 
-    @Schema(type = "Long", example = "1", description = "독서 시간의 id")
+    @Schema(type = "Long", example = "1", description = "독서 기록 시간의 id")
     public Long timerId;
 
-    @Schema(type = "LocalDate", example = "2025-01-21", description = "타이머를 시작한 일시입니다.")
-    public LocalDate date;
+    @Schema(type = "LocalDateTime", example = "2024-11-05 21:13:56.564098", description = "타이머를 종료한 일시입니다.")
+    public LocalDateTime date;
 
     @Schema(type = "String", example = "01:20:00", description = "독서 시간입니다. HH:MM:SS 형식입니다.")
     public String readTime;

--- a/src/main/java/com/nookbook/domain/timer/dto/response/TimerRes.java
+++ b/src/main/java/com/nookbook/domain/timer/dto/response/TimerRes.java
@@ -6,8 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.Duration;
-import java.time.LocalTime;
 import java.util.List;
 
 @Getter
@@ -16,7 +14,7 @@ import java.util.List;
 @AllArgsConstructor
 public class TimerRes {
 
-    @Schema(type = "String", example = "01:20:00", description = "독서 시간입니다. HH:MM:SS 형식입니다.")
+    @Schema(type = "String", example = "01:20:00", description = "누적 독서 시간입니다. HH:MM:SS 형식입니다.")
     public String totalReadTime;
 
     @Schema(type = "array", description = "Schemas의 TimerRecordRes를 참고해주세요. 타이머를 이용해 기록된 독서 시간의 리스트입니다.")

--- a/src/main/java/com/nookbook/domain/timer/dto/response/TimerRes.java
+++ b/src/main/java/com/nookbook/domain/timer/dto/response/TimerRes.java
@@ -1,0 +1,25 @@
+package com.nookbook.domain.timer.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Duration;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimerRes {
+
+    @Schema(type = "String", example = "01:20:00", description = "독서 시간입니다. HH:MM:SS 형식입니다.")
+    public String totalReadTime;
+
+    @Schema(type = "array", description = "Schemas의 TimerRecordRes를 참고해주세요. 타이머를 이용해 기록된 독서 시간의 리스트입니다.")
+    private List<TimerRecordRes> recordResList;
+
+}

--- a/src/main/java/com/nookbook/domain/user_book/domain/UserBook.java
+++ b/src/main/java/com/nookbook/domain/user_book/domain/UserBook.java
@@ -8,6 +8,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigInteger;
+import java.time.Duration;
+import java.time.LocalTime;
+
 @Entity
 @Table(name="User_Book")
 @NoArgsConstructor
@@ -27,6 +31,9 @@ public class UserBook extends BaseEntity {
     @JoinColumn(name = "book_id")
     private Book book;
 
+    // 누적 독서 시간
+    private BigInteger totalReadTime = BigInteger.ZERO;
+
     @Enumerated(EnumType.STRING)
     private BookStatus bookStatus = BookStatus.BEFORE_READ;
 
@@ -38,4 +45,6 @@ public class UserBook extends BaseEntity {
     }
 
     public void updateBookStatus(BookStatus bookStatus) { this.bookStatus = bookStatus; }
+
+    public void updateTotalReadTime(BigInteger totalReadTime) { this.totalReadTime = totalReadTime; }
 }

--- a/src/main/java/com/nookbook/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/nookbook/global/config/security/SecurityConfig.java
@@ -80,7 +80,7 @@ public class SecurityConfig {
                         .permitAll()
                         .requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**")
                         .permitAll()
-                        .requestMatchers("/login/**", "/auth/idTokenLogin", "/oauth2/**", "api/v1/**")
+                        .requestMatchers("/login/**", "/auth/idTokenLogin", "/oauth2/**", "/api/v1/**")
                         .permitAll()
                         .anyRequest()
                         .authenticated())


### PR DESCRIPTION
## 👑 Summary
> 어떤 내용의 PR인가요?
- 타이머 관련 API(타이머 저장 및 조회)를 구현합니다

## 🫧 To be noted
> PR을 검토할 때 확인해야 할 사항이 있나요?
- 타이머 저장 시 최대 10개까지만 저장됩니다! 따라서 10개 째에 저장 요청이 올 경우 가장 오래된 기록을 삭제합니다(명세서 참고)

## 💫 issue number
> 이슈 번호를 작성해주새요
- resolve #68 

## ☑️ Checklist
> PR 요청 시 체크해주세요.
- [x] label
- [x] issue number
- [x] conflict resolve

## 💡 Comment
> 전달하고 싶은 내용이 있나요?
- 타이머 시간 저장 시 bigint 타입을 사용합니다. 따라서 요청은 초단위로 받으며, 응답에서는 HH:MM:SS 형식으로 반환합니다.
- user_book에 `누적 독서 시간` 컬럼을 추가하고, user_book과 연결된 timer 테이블을 생성해 각각의 독서 시간 기록을 저장했습니다.