### PR TITLE
[FEAT] 친구 관련 API 구현

### DIFF
--- a/src/main/java/com/nookbook/domain/book/applicaiton/BookService.java
+++ b/src/main/java/com/nookbook/domain/book/applicaiton/BookService.java
@@ -196,6 +196,7 @@ public class BookService {
         Book book = Book.builder()
                 .title(bookDetailRes.getTitle())
                 .author(bookDetailRes.getAuthor())
+                .publisher(bookDetailRes.getPublisher())
                 .image(bookDetailRes.getCover())
                 .page(bookDetailRes.getPage())
                 .isbn(bookDetailRes.getIsbn13())
@@ -325,12 +326,13 @@ public class BookService {
     }
 
     // 독서 리포트 - 카테고리
-    public ResponseEntity<ApiResponse> countReadBooksByCategory(UserPrincipal userPrincipal) {
+    public ResponseEntity<ApiResponse> countReadBooksByCategory(UserPrincipal userPrincipal, Long userId) {
         // User user = validUserById(userPrincipal.getId());
         User user = validUserById(1L);
+        User targetUser = validUserById(userId);
         // groupby에 따라서 카테고리에 맞는 점수 배정
         // 읽은 책 조회
-        List<UserBook> userBooks = userBookRepository.findByUserAndBookStatus(user, BookStatus.READ);
+        List<UserBook> userBooks = userBookRepository.findByUserAndBookStatus(targetUser, BookStatus.READ);
 
         // 카테고리별로 그룹화하여 카운트 (카테고리명과 그에 대한 책 수를 매핑)
         Map<String, Long> categoryCountMap = userBooks.stream()
@@ -358,10 +360,11 @@ public class BookService {
     }
 
     // 독서 리포트 - 독서 통계
-    public ResponseEntity<ApiResponse> countReadBooksByYear(UserPrincipal userPrincipal, int year) {
+    public ResponseEntity<ApiResponse> countReadBooksByYear(UserPrincipal userPrincipal, Long userId,  int year) {
         // User user = validUserById(userPrincipal.getId());
         User user = validUserById(1L);
-        List<UserBook> userBooks = userBookRepository.findUserBooksByStatusAndYear(user, BookStatus.READ, year);
+        User targetUser = validUserById(userId);
+        List<UserBook> userBooks = userBookRepository.findUserBooksByStatusAndYear(targetUser, BookStatus.READ, year);
 
         // 월별로 그룹화하여 카운트
         Map<Integer, Long> monthCountMap = userBooks.stream()
@@ -390,7 +393,7 @@ public class BookService {
 
     private User validUserById(Long userId) {
         // Optional<User> userOptional = userRepository.findById(userId);
-        Optional<User> userOptional = userRepository.findById(1L);
+        Optional<User> userOptional = userRepository.findById(userId);
         DefaultAssert.isTrue(userOptional.isPresent(), "유효한 사용자가 아닙니다.");
         return userOptional.get();
     }

--- a/src/main/java/com/nookbook/domain/book/applicaiton/BookService.java
+++ b/src/main/java/com/nookbook/domain/book/applicaiton/BookService.java
@@ -329,7 +329,7 @@ public class BookService {
     public ResponseEntity<ApiResponse> countReadBooksByCategory(UserPrincipal userPrincipal, Long userId) {
         // User user = validUserById(userPrincipal.getId());
         User user = validUserById(1L);
-        User targetUser = validUserById(userId);
+        User targetUser = userId != null ? validUserById(userId) : user;
         // groupby에 따라서 카테고리에 맞는 점수 배정
         // 읽은 책 조회
         List<UserBook> userBooks = userBookRepository.findByUserAndBookStatus(targetUser, BookStatus.READ);
@@ -363,7 +363,7 @@ public class BookService {
     public ResponseEntity<ApiResponse> countReadBooksByYear(UserPrincipal userPrincipal, Long userId,  int year) {
         // User user = validUserById(userPrincipal.getId());
         User user = validUserById(1L);
-        User targetUser = validUserById(userId);
+        User targetUser = userId != null ? validUserById(userId) : user;
         List<UserBook> userBooks = userBookRepository.findUserBooksByStatusAndYear(targetUser, BookStatus.READ, year);
 
         // 월별로 그룹화하여 카운트

--- a/src/main/java/com/nookbook/domain/book/domain/Book.java
+++ b/src/main/java/com/nookbook/domain/book/domain/Book.java
@@ -34,6 +34,9 @@ public class Book {
     @Column(name="publishedDate")
     private LocalDate publishedDate;
 
+    @Column(name = "publisher")
+    private String publisher;
+
     @Column(name="info", columnDefinition = "TEXT")
     private String info;
 
@@ -50,9 +53,10 @@ public class Book {
     private String link;
 
     @Builder
-    public Book(String title, String author, int page, String isbn, LocalDate publishedDate, String info, String idx, String category, String image, String link) {
+    public Book(String title, String author, String publisher, int page, String isbn, LocalDate publishedDate, String info, String idx, String category, String image, String link) {
         this.title = title;
         this.author = author;
+        this.publisher = publisher;
         this.page = page;
         this.isbn = isbn;
         this.publishedDate = publishedDate;

--- a/src/main/java/com/nookbook/domain/book/dto/response/BookDetailRes.java
+++ b/src/main/java/com/nookbook/domain/book/dto/response/BookDetailRes.java
@@ -58,6 +58,10 @@ public class BookDetailRes {
     @Schema(type = "String", example = "소설/시/희곡", description = "도서의 카테고리입니다.")
     private String category;
 
+    @JsonProperty("publisher")
+    @Schema(type = "String", example = "데이원", description = "도서의 출판사")
+    private String publisher;
+
 
     public void setToc(String toc) {
         this.toc = toc;

--- a/src/main/java/com/nookbook/domain/note/application/NoteService.java
+++ b/src/main/java/com/nookbook/domain/note/application/NoteService.java
@@ -6,10 +6,7 @@ import com.nookbook.domain.note.domain.Note;
 import com.nookbook.domain.note.domain.repository.NoteRepository;
 import com.nookbook.domain.note.dto.request.CreateNoteReq;
 import com.nookbook.domain.note.dto.request.UpdateNoteReq;
-import com.nookbook.domain.note.dto.response.ImageUrlRes;
-import com.nookbook.domain.note.dto.response.NoteDetailRes;
-import com.nookbook.domain.note.dto.response.NoteListRes;
-import com.nookbook.domain.note.dto.response.NoteRes;
+import com.nookbook.domain.note.dto.response.*;
 import com.nookbook.domain.user.domain.User;
 import com.nookbook.domain.user.domain.repository.UserRepository;
 import com.nookbook.domain.user_book.domain.BookStatus;
@@ -118,7 +115,7 @@ public class NoteService {
     }
 
     // 책 정보 조회(제목, 이미지) && 노트 목록 조회
-    public ResponseEntity<?> getNoteList(UserPrincipal userPrincipal, Long bookId) {
+    public ResponseEntity<?> getNoteListByBookId(UserPrincipal userPrincipal, Long bookId) {
         // User user = validUserById(userPrincipal.getId());
         User user = validUserById(1L);
         Book book = validBookById(bookId);
@@ -193,9 +190,34 @@ public class NoteService {
         return ResponseEntity.ok(apiResponse);
     }
 
+    public ResponseEntity<?> getNoteList(UserPrincipal userPrincipal, Long userId) {
+        // User user = validUserById(userPrincipal.getId());
+        User user = validUserById(1L);
+        User targetUser = validUserById(userId);
+        List<UserBook> userBooks = userBookRepository.findByUser(targetUser);
+        List<Note> notes = noteRepository.findByUserBookInOrderByCreatedAtDesc(userBooks);
+
+        List<OtherUserNoteListRes> noteListRes = notes.stream()
+                .map(note -> {
+                    Book book = note.getUserBook().getBook();
+                    return OtherUserNoteListRes.builder()
+                            .bookId(book.getBookId())
+                            .cover(book.getImage())
+                            .title(book.getTitle())
+                            .author(book.getAuthor())
+                            .publisher(book.getPublisher())
+                            .build();
+                })
+                .toList();
+        return ResponseEntity.ok(ApiResponse.builder()
+                        .check(true)
+                        .information(noteListRes)
+                        .build());
+    }
+
     private User validUserById(Long userId) {
         // Optional<User> userOptional = userRepository.findById(userId);
-        Optional<User> userOptional = userRepository.findById(1L);
+        Optional<User> userOptional = userRepository.findById(userId);
         DefaultAssert.isTrue(userOptional.isPresent(), "유효한 사용자가 아닙니다.");
         return userOptional.get();
     }

--- a/src/main/java/com/nookbook/domain/note/application/NoteService.java
+++ b/src/main/java/com/nookbook/domain/note/application/NoteService.java
@@ -190,11 +190,16 @@ public class NoteService {
         return ResponseEntity.ok(apiResponse);
     }
 
-    public ResponseEntity<?> getNoteList(UserPrincipal userPrincipal, Long userId) {
+    public ResponseEntity<?> getNoteList(UserPrincipal userPrincipal, Long userId, String keyword) {
         // User user = validUserById(userPrincipal.getId());
         User user = validUserById(1L);
         User targetUser = validUserById(userId);
-        List<UserBook> userBooks = userBookRepository.findByUser(targetUser);
+        List<UserBook> userBooks;
+        if (keyword == null) {
+            userBooks = userBookRepository.findByUser(targetUser);
+        } else {
+            userBooks = userBookRepository.findByUserAndBookTitleLike(targetUser, keyword);
+        }
         List<Note> notes = noteRepository.findByUserBookInOrderByCreatedAtDesc(userBooks);
 
         List<OtherUserNoteListRes> noteListRes = notes.stream()

--- a/src/main/java/com/nookbook/domain/note/domain/repository/NoteRepository.java
+++ b/src/main/java/com/nookbook/domain/note/domain/repository/NoteRepository.java
@@ -14,4 +14,6 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
     boolean existsByUserBook(UserBook userBook);
 
     List<Note> findByUserBookOrderByCreatedAtDesc(UserBook userBook);
+
+    List<Note> findByUserBookInOrderByCreatedAtDesc(List<UserBook> userBooks);
 }

--- a/src/main/java/com/nookbook/domain/note/dto/response/OtherUserNoteListRes.java
+++ b/src/main/java/com/nookbook/domain/note/dto/response/OtherUserNoteListRes.java
@@ -1,0 +1,29 @@
+package com.nookbook.domain.note.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OtherUserNoteListRes {
+
+    @Schema(type = "Long", example = "1", description = "도서의 bookId")
+    private Long bookId;
+
+    @Schema(type = "String", example = "몰입 : 인생을 바꾸는 자기 혁명 - Think Hard!", description = "도서의 제목")
+    private String title;
+
+    @Schema(type = "String", example = "https://image.aladin.co.kr/product/102/9/coversum/s552832633_2.jpg", description = "도서의 이미지")
+    private String cover;
+
+    @Schema(type = "String", example = "황농문 (지은이)", description = "도서의 저자")
+    private String author;
+
+    @Schema(type = "String", example = "데이원", description = "도서의 출판사")
+    private String publisher;
+}

--- a/src/main/java/com/nookbook/domain/note/presentation/NoteController.java
+++ b/src/main/java/com/nookbook/domain/note/presentation/NoteController.java
@@ -93,7 +93,7 @@ public class NoteController {
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "도서의 id를 입력해주세요.", required = true) @PathVariable Long bookId
     ) {
-        return noteService.getNoteList(userPrincipal, bookId);
+        return noteService.getNoteListByBookId(userPrincipal, bookId);
     }
 
     @Operation(summary = "이미지 업로드", description = "이미지를 업로드하고, URL을 반환합니다.")

--- a/src/main/java/com/nookbook/domain/user/application/FriendService.java
+++ b/src/main/java/com/nookbook/domain/user/application/FriendService.java
@@ -63,7 +63,7 @@ public class FriendService {
         User targetUser = validUserByUserId(userId);
         DefaultAssert.isTrue(targetUser != user, "본인에게 친구 요청을 보낼 수 없습니다.");
 
-        boolean available = friendRepository.existsBySenderAndReceiver(user, targetUser) || friendRepository.existsByReceiverAndSender(targetUser, user);
+        boolean available = !friendRepository.existsBySenderAndReceiver(user, targetUser) || !friendRepository.existsByReceiverAndSender(targetUser, user);
         DefaultAssert.isTrue(available, "이미 친구 요청을 보내거나 받은 상태입니다.");
 
         Friend friend = Friend.builder()

--- a/src/main/java/com/nookbook/domain/user/application/FriendService.java
+++ b/src/main/java/com/nookbook/domain/user/application/FriendService.java
@@ -60,6 +60,11 @@ public class FriendService {
         // User user = validUserByUserId(userPrincipal.getId());
         User user = validUserByUserId(1L);
         User targetUser = validUserByUserId(userId);
+        DefaultAssert.isTrue(targetUser != user, "본인에게 친구 요청을 보낼 수 없습니다.");
+
+        boolean available = friendRepository.existsBySenderAndReceiver(user, targetUser) || friendRepository.existsByReceiverAndSender(targetUser, user);
+        DefaultAssert.isTrue(available, "이미 친구 요청을 보내거나 받은 상태입니다.");
+
         Friend friend = Friend.builder()
                 .sender(user)
                 .receiver(targetUser)
@@ -103,6 +108,7 @@ public class FriendService {
 
     // 친구 요청 삭제
     // 친구 요청 수락
+
 
     private User validUserByUserId(Long userId) {
         Optional<User> user = userRepository.findById(userId);

--- a/src/main/java/com/nookbook/domain/user/application/FriendService.java
+++ b/src/main/java/com/nookbook/domain/user/application/FriendService.java
@@ -1,0 +1,85 @@
+package com.nookbook.domain.user.application;
+
+import com.nookbook.domain.user.domain.Friend;
+import com.nookbook.domain.user.domain.FriendRequestStatus;
+import com.nookbook.domain.user.domain.User;
+import com.nookbook.domain.user.domain.repository.FriendRepository;
+import com.nookbook.domain.user.domain.repository.UserRepository;
+import com.nookbook.domain.user.dto.response.SearchUserRes;
+import com.nookbook.global.DefaultAssert;
+import com.nookbook.global.config.security.token.UserPrincipal;
+import com.nookbook.global.payload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FriendService {
+
+    private final UserRepository userRepository;
+    private final FriendRepository friendRepository;
+
+    // 검색
+    public ResponseEntity<?> searchUsers(UserPrincipal userPrincipal, boolean isFriend, String keyword) {
+        // User user = validUserByUserId(userPrincipal.getId());
+        User user = validUserByUserId(1L);
+        List<User> findUsers = isFriend ? getFriendsByKeyword(user, keyword) : getAllUsersByKeyword(user, keyword);
+        List<SearchUserRes> searchUserRes = findUsers.stream()
+                .map(findUser -> SearchUserRes.builder()
+                        .userId(findUser.getUserId())
+                        .nickname(findUser.getNickname())
+                        .imageUrl(findUser.getImageUrl())
+                        .build())
+                .toList();
+        return ResponseEntity.ok(ApiResponse.builder()
+                .check(true)
+                .information(searchUserRes)
+                .build());
+    }
+
+    private List<User> getAllUsersByKeyword(User user, String keyword) {
+        return userRepository.findUsersNotInFriendByKeyword(user, keyword);
+    }
+
+    private List<User> getFriendsByKeyword(User user, String keyword) {
+        return keyword != null ?
+                userRepository.findUsersInFriendByKeyword(user, keyword, FriendRequestStatus.FRIEND_ACCEPT)
+                : userRepository.findUsersInFriend(user, FriendRequestStatus.FRIEND_ACCEPT);
+    }
+
+    // 친구 요청
+    @Transactional
+    public ResponseEntity<?> sendFriendRequest(UserPrincipal userPrincipal, Long userId) {
+        // User user = validUserByUserId(userPrincipal.getId());
+        User user = validUserByUserId(1L);
+        User targetUser = validUserByUserId(userId);
+        Friend friend = Friend.builder()
+                .sender(user)
+                .receiver(targetUser)
+                .build();
+        friendRepository.save(friend);
+        return ResponseEntity.ok(ApiResponse.builder()
+                .check(true)
+                .information("친구 신청이 완료되었습니다.")
+                .build());
+    }
+
+    // 친구 요청 보낸/받은 목록 조회
+    // 친구 목록 조회
+
+    // 친구 요청 삭제
+    // 친구 요청 수락
+
+    private User validUserByUserId(Long userId) {
+        Optional<User> user = userRepository.findById(userId);
+        DefaultAssert.isTrue(user.isPresent(), "사용자가 존재하지 않습니다.");
+        return user.get();
+    }
+}

--- a/src/main/java/com/nookbook/domain/user/application/UserService.java
+++ b/src/main/java/com/nookbook/domain/user/application/UserService.java
@@ -190,7 +190,7 @@ public class UserService {
         Optional<Friend> friendOptional = friendRepository.findBySenderAndReceiver(user, targetUser)
                 .or(() -> friendRepository.findBySenderAndReceiver(targetUser, user));
         return friendOptional.map(friend -> {
-            if (friend.getStatus() == FriendRequestStatus.FRIEND_REQUEST) {
+            if (friend.getFriendRequestStatus() == FriendRequestStatus.FRIEND_REQUEST) {
                 return user.equals(friend.getSender()) ? "REQUEST_SENT" : "REQUEST_RECEIVED";
             } else {
                 return friend.getStatus().toString();

--- a/src/main/java/com/nookbook/domain/user/application/UserService.java
+++ b/src/main/java/com/nookbook/domain/user/application/UserService.java
@@ -3,13 +3,16 @@ package com.nookbook.domain.user.application;
 import com.nookbook.domain.collection.domain.Collection;
 import com.nookbook.domain.collection.domain.CollectionStatus;
 import com.nookbook.domain.collection.domain.repository.CollectionRepository;
+import com.nookbook.domain.user.domain.Friend;
+import com.nookbook.domain.user.domain.FriendRequestStatus;
+import com.nookbook.domain.user.domain.repository.FriendRepository;
 import com.nookbook.infrastructure.s3.S3Uploader;
 import com.nookbook.domain.user.domain.User;
 import com.nookbook.domain.user.domain.repository.UserRepository;
 import com.nookbook.domain.user.dto.request.NicknameIdCheckReq;
 import com.nookbook.domain.user.dto.request.NicknameCheckReq;
 import com.nookbook.domain.user.dto.request.UserInfoReq;
-import com.nookbook.domain.user.dto.response.MyInfoRes;
+import com.nookbook.domain.user.dto.response.UserInfoRes;
 import com.nookbook.domain.user.dto.response.NicknameCheckRes;
 import com.nookbook.domain.user.dto.response.NicknameIdCheckRes;
 import com.nookbook.global.DefaultAssert;
@@ -36,6 +39,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final S3Uploader s3Uploader;
     private final CollectionRepository collectionRepository;
+    private final FriendRepository friendRepository;
 
     @Transactional
     public void saveUser(User user) {
@@ -160,26 +164,40 @@ public class UserService {
         return !userRepository.existsByNickname(nickname);
     }
 
-    // 내 정보 조회
-    // 닉네임 아이디 친구 수
-    public ResponseEntity<ApiResponse> getMyInfo(UserPrincipal userPrincipal) {
+    // 정보 조회
+    public ResponseEntity<ApiResponse> getUserInfo(UserPrincipal userPrincipal, Long userId) {
         // User user = validUserByUserId(userPrincipal.getId());
         User user = validUserByUserId(1L);
-        // TODO: 친구 수 구하는 로직
-        int num = 0;
-        MyInfoRes myInfoRes = MyInfoRes.builder()
-                .nicknameId(user.getNicknameId())
-                .nickname(user.getNickname())
-                .imageUrl(user.getImageUrl())
-                .friendsNum(num)
-                .build();
+        User targetUser = userId != null ? validUserByUserId(userId) : user;
 
+        int num = friendRepository.countBySenderOrReceiverAndFriendRequestStatus(targetUser, FriendRequestStatus.FRIEND_ACCEPT);
+        String friendRequestStatus = user != targetUser ? determineFriendStatus(user, targetUser) : null;
+        UserInfoRes userInfoRes = UserInfoRes.builder()
+                .nicknameId(targetUser.getNicknameId())
+                .nickname(targetUser.getNickname())
+                .imageUrl(targetUser.getImageUrl())
+                .friendsNum(num)
+                .requestStatus(friendRequestStatus)
+                .build();
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)
-                .information(myInfoRes)
+                .information(userInfoRes)
                 .build();
         return ResponseEntity.ok(apiResponse);
     }
+
+    private String determineFriendStatus(User user, User targetUser) {
+        Optional<Friend> friendOptional = friendRepository.findBySenderAndReceiver(user, targetUser)
+                .or(() -> friendRepository.findBySenderAndReceiver(targetUser, user));
+        return friendOptional.map(friend -> {
+            if (friend.getStatus() == FriendRequestStatus.FRIEND_REQUEST) {
+                return user.equals(friend.getSender()) ? "REQUEST_SENT" : "REQUEST_RECEIVED";
+            } else {
+                return friend.getStatus().toString();
+            }
+        }).orElse("NONE");
+    }
+
 
     // 프로필 사진 등록
     @Transactional

--- a/src/main/java/com/nookbook/domain/user/domain/Friend.java
+++ b/src/main/java/com/nookbook/domain/user/domain/Friend.java
@@ -34,7 +34,7 @@ public class Friend extends BaseEntity {
         this.receiver = receiver;
     }
 
-    public void updateFriendRequestStatus(FriendRequestStatus status) {
-        this.friendRequestStatus = status;
+    public void updateFriendRequestStatus(FriendRequestStatus friendRequestStatus) {
+        this.friendRequestStatus = friendRequestStatus;
     }
 }

--- a/src/main/java/com/nookbook/domain/user/domain/Friend.java
+++ b/src/main/java/com/nookbook/domain/user/domain/Friend.java
@@ -1,5 +1,6 @@
 package com.nookbook.domain.user.domain;
 
+import com.nookbook.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Table(name="Friend")
 @NoArgsConstructor
 @Getter
-public class Friend {
+public class Friend extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,12 +26,15 @@ public class Friend {
     private User receiver;
 
     @Enumerated(EnumType.STRING)
-    private FriendRequestStatus status;
+    private FriendRequestStatus friendRequestStatus = FriendRequestStatus.FRIEND_REQUEST;
 
     @Builder
-    public Friend(User sender, User receiver, FriendRequestStatus status) {
+    public Friend(User sender, User receiver) {
         this.sender = sender;
         this.receiver = receiver;
-        this.status = status;
+    }
+
+    public void updateFriendRequestStatus(FriendRequestStatus status) {
+        this.friendRequestStatus = status;
     }
 }

--- a/src/main/java/com/nookbook/domain/user/domain/Friend.java
+++ b/src/main/java/com/nookbook/domain/user/domain/Friend.java
@@ -1,0 +1,36 @@
+package com.nookbook.domain.user.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="Friend")
+@NoArgsConstructor
+@Getter
+public class Friend {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="friend_id", updatable = false, nullable = false, unique = true)
+    private Long friendId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id")
+    private User sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id")
+    private User receiver;
+
+    @Enumerated(EnumType.STRING)
+    private FriendRequestStatus status;
+
+    @Builder
+    public Friend(User sender, User receiver, FriendRequestStatus status) {
+        this.sender = sender;
+        this.receiver = receiver;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/nookbook/domain/user/domain/FriendRequestStatus.java
+++ b/src/main/java/com/nookbook/domain/user/domain/FriendRequestStatus.java
@@ -1,0 +1,10 @@
+package com.nookbook.domain.user.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum FriendRequestStatus {
+
+    FRIEND_REQUEST,  // sender가 receiver에게 친구 요청
+    FRIEND_ACCEPT;    // 친구
+}

--- a/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
+++ b/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
@@ -19,4 +19,7 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
             "WHERE (f.sender = :user OR f.receiver = :user) AND f.friendRequestStatus = :friendRequestStatus")
     int countBySenderOrReceiverAndFriendRequestStatus(@Param("user") User user, @Param("friendRequestStatus") FriendRequestStatus friendRequestStatus);
 
+    List<Friend> findBySenderAndFriendRequestStatus(User user, FriendRequestStatus friendRequestStatus);
+
+    List<Friend> findByReceiverAndFriendRequestStatus(User user, FriendRequestStatus friendRequestStatus);
 }

--- a/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
+++ b/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
@@ -1,0 +1,21 @@
+package com.nookbook.domain.user.domain.repository;
+
+import com.nookbook.domain.user.domain.Friend;
+import com.nookbook.domain.user.domain.FriendRequestStatus;
+import com.nookbook.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface FriendRepository extends JpaRepository<Friend, Long> {
+    Optional<Friend> findBySenderAndReceiver(User user, User targetUser);
+    @Query("SELECT COUNT(f) " +
+            "FROM Friend f " +
+            "WHERE (f.sender = :user OR f.receiver = :user) AND f.status = :status")
+    int countBySenderOrReceiverAndFriendRequestStatus(@Param("user") User user, @Param("status") FriendRequestStatus status);
+
+}

--- a/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
+++ b/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
@@ -22,4 +22,8 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     List<Friend> findBySenderAndFriendRequestStatus(User user, FriendRequestStatus friendRequestStatus);
 
     List<Friend> findByReceiverAndFriendRequestStatus(User user, FriendRequestStatus friendRequestStatus);
+
+    boolean existsBySenderAndReceiver(User user, User targetUser);
+
+    boolean existsByReceiverAndSender(User targetUser, User user);
 }

--- a/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
+++ b/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -15,7 +16,7 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     Optional<Friend> findBySenderAndReceiver(User user, User targetUser);
     @Query("SELECT COUNT(f) " +
             "FROM Friend f " +
-            "WHERE (f.sender = :user OR f.receiver = :user) AND f.status = :status")
-    int countBySenderOrReceiverAndFriendRequestStatus(@Param("user") User user, @Param("status") FriendRequestStatus status);
+            "WHERE (f.sender = :user OR f.receiver = :user) AND f.friendRequestStatus = :friendRequestStatus")
+    int countBySenderOrReceiverAndFriendRequestStatus(@Param("user") User user, @Param("friendRequestStatus") FriendRequestStatus friendRequestStatus);
 
 }

--- a/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
+++ b/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
@@ -26,4 +26,25 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     boolean existsBySenderAndReceiver(User user, User targetUser);
 
     boolean existsByReceiverAndSender(User targetUser, User user);
+
+    @Query("SELECT f FROM Friend f " +
+            "WHERE (" +
+            "    (f.sender = :user AND (f.receiver.nickname LIKE %:keyword%  OR f.receiver.nicknameId LIKE %:keyword% )) " +
+            "    OR " +
+            "    (f.receiver = :user AND (f.sender.nickname LIKE %:keyword% OR f.sender.nicknameId LIKE %:keyword%)) " +
+            ") " +
+            "AND f.friendRequestStatus = :friendRequestStatus")
+    List<Friend> findBySenderOrReceiverAndStatusAndNicknameLikeKeyword(
+            @Param("user") User user,
+            @Param("keyword") String keyword,
+            @Param("friendRequestStatus") FriendRequestStatus friendRequestStatus);
+
+    @Query("SELECT f FROM Friend f " +
+            "WHERE (f.sender = :user OR f.receiver = :user) " +
+            "AND f.friendRequestStatus = :friendRequestStatus")
+    List<Friend> findBySenderOrReceiverAndStatus(
+            @Param("user") User user,
+            @Param("friendRequestStatus") FriendRequestStatus friendRequestStatus);
+
+
 }

--- a/src/main/java/com/nookbook/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/nookbook/domain/user/domain/repository/UserRepository.java
@@ -28,19 +28,4 @@ public interface UserRepository extends JpaRepository<User, Long>{
             "AND (u.nicknameId LIKE %:keyword% OR u.nickname LIKE %:keyword%)")
     List<User> findUsersNotInFriendByKeyword(@Param("user") User user, @Param("keyword") String keyword);
 
-    @Query("SELECT u " +
-            "FROM User u " +
-            "WHERE (u.nicknameId = :keyword OR u.nickname LIKE %:keyword%) " +
-            "AND (u IN (SELECT f.receiver FROM Friend f WHERE f.sender = :user AND f.friendRequestStatus = :friendRequestStatus) " +
-            "OR u IN (SELECT f.sender FROM Friend f WHERE f.receiver = :user AND f.friendRequestStatus = :friendRequestStatus))")
-    List<User> findUsersInFriendByKeyword(@Param("user") User user, @Param("keyword") String keyword, @Param("friendRequestStatus") FriendRequestStatus friendRequestStatus);
-
-    @Query("SELECT DISTINCT u " +
-            "FROM User u " +
-            "JOIN Friend f ON (f.sender = :user OR f.receiver = :user) " +
-            "WHERE (f.sender = u OR f.receiver = u) " +
-            "AND f.friendRequestStatus = :friendRequestStatus")
-    List<User> findUsersInFriend(@Param("user") User user, @Param("friendRequestStatus") FriendRequestStatus friendRequestStatus);
-
-
 }

--- a/src/main/java/com/nookbook/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/nookbook/domain/user/domain/repository/UserRepository.java
@@ -1,9 +1,13 @@
 package com.nookbook.domain.user.domain.repository;
 
+import com.nookbook.domain.user.domain.FriendRequestStatus;
 import com.nookbook.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,4 +18,29 @@ public interface UserRepository extends JpaRepository<User, Long>{
     boolean existsByNicknameId(String nicknameId);
 
     boolean existsByNickname(String nickname);
+
+    @Query("SELECT u FROM User u " +
+            "WHERE u != :user " +
+            "AND NOT EXISTS (" +
+            "    SELECT 1 FROM Friend f " +
+            "    WHERE (f.sender = :user AND f.receiver = u) OR (f.receiver = :user AND f.sender = u)" +
+            ") " +
+            "AND (u.nicknameId LIKE %:keyword% OR u.nickname LIKE %:keyword%)")
+    List<User> findUsersNotInFriendByKeyword(@Param("user") User user, @Param("keyword") String keyword);
+
+    @Query("SELECT u " +
+            "FROM User u " +
+            "WHERE (u.nicknameId = :keyword OR u.nickname LIKE %:keyword%) " +
+            "AND (u IN (SELECT f.receiver FROM Friend f WHERE f.sender = :user AND f.friendRequestStatus = :friendRequestStatus) " +
+            "OR u IN (SELECT f.sender FROM Friend f WHERE f.receiver = :user AND f.friendRequestStatus = :friendRequestStatus))")
+    List<User> findUsersInFriendByKeyword(@Param("user") User user, @Param("keyword") String keyword, @Param("friendRequestStatus") FriendRequestStatus friendRequestStatus);
+
+    @Query("SELECT DISTINCT u " +
+            "FROM User u " +
+            "JOIN Friend f ON (f.sender = :user OR f.receiver = :user) " +
+            "WHERE (f.sender = u OR f.receiver = u) " +
+            "AND f.friendRequestStatus = :friendRequestStatus")
+    List<User> findUsersInFriend(@Param("user") User user, @Param("friendRequestStatus") FriendRequestStatus friendRequestStatus);
+
+
 }

--- a/src/main/java/com/nookbook/domain/user/dto/response/FriendsRequestRes.java
+++ b/src/main/java/com/nookbook/domain/user/dto/response/FriendsRequestRes.java
@@ -1,0 +1,22 @@
+package com.nookbook.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FriendsRequestRes {
+
+    @Schema(description = "Schemas의 SearchUserRes를 확인해주세요. 내가 보낸 요청의 목록입니다.")
+    private List<SearchUserRes> sentRequest;
+
+    @Schema(description = "Schemas의 SearchUserRes를 확인해주세요. 내가 받은 요청의 목록입니다.")
+    private List<SearchUserRes> receivedRequest;
+}

--- a/src/main/java/com/nookbook/domain/user/dto/response/SearchUserRes.java
+++ b/src/main/java/com/nookbook/domain/user/dto/response/SearchUserRes.java
@@ -1,5 +1,6 @@
 package com.nookbook.domain.user.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,6 +15,10 @@ public class SearchUserRes {
 
     @Schema(type = "Long", example = "1", description = "사용자의 아이디입니다.")
     private Long userId;
+
+    @Schema(type = "Long", example = "1", description = "친구 및 친구 요청의 아이디입니다.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Long friendId;
 
     @Schema(type = "String", example = "기무라타쿠야가되", description = "사용자의 닉네임입니다.")
     private String nickname;

--- a/src/main/java/com/nookbook/domain/user/dto/response/SearchUserRes.java
+++ b/src/main/java/com/nookbook/domain/user/dto/response/SearchUserRes.java
@@ -1,0 +1,23 @@
+package com.nookbook.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SearchUserRes {
+
+    @Schema(type = "Long", example = "1", description = "사용자의 아이디입니다.")
+    private Long userId;
+
+    @Schema(type = "String", example = "기무라타쿠야가되", description = "사용자의 닉네임입니다.")
+    private String nickname;
+
+    @Schema(type = "String", example = "https://nookbook-s3-bucket.amazons.com/akfjvndij0e3.png", description = "사용자의 프로필 사진 URL입니다.")
+    private String imageUrl;
+}

--- a/src/main/java/com/nookbook/domain/user/dto/response/UserInfoRes.java
+++ b/src/main/java/com/nookbook/domain/user/dto/response/UserInfoRes.java
@@ -1,5 +1,6 @@
 package com.nookbook.domain.user.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class MyInfoRes {
+public class UserInfoRes {
 
     @Schema(type = "String", example = "minjufish", description = "사용자의 (이메일이 아닌) 친구 식별용 아이디입니다.")
     private String nicknameId;
@@ -23,4 +24,9 @@ public class MyInfoRes {
 
     @Schema(type = "int", example = "12", description = "특정 사용자의 친구 수 입니다.")
     private int friendsNum;
+
+    @Schema(type = "String", example = "REQUEST_SENT",
+            description = "친구 신청 현황입니다. REQUEST_SENT: 내가 userId에게 친구 신청을 보냄, REQUEST_RECEIVED: userId가 나에게 친구 신청을 보냄, FRIEND_ACCEPT: 친구 상태, NONE: 요청을 보낸/받은 적 없음")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String requestStatus;
 }

--- a/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
+++ b/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
@@ -118,7 +118,7 @@ public class MyPageController {
         return userService.getUserInfo(userPrincipal, userId);
     }
 
-    @Operation(summary = "[마이페이지] 기록 전체보기 목록 조회", description = "친구페이지의 기록 전체보기 목록을 조회합니다.")
+    @Operation(summary = "[마이페이지] 기록 전체보기 목록 조회 및 검색", description = "친구페이지의 기록 전체보기 목록 조회 또는 검색하여 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = OtherUserNoteListRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
@@ -126,8 +126,10 @@ public class MyPageController {
     @GetMapping("/note/{userId}")
     public ResponseEntity<?> findUserAllNotes(
             @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.") @PathVariable Long userId
+            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.") @PathVariable Long userId,
+            @Parameter(description = "검색하고자 하는 단어를 입력해주세요. 없다면 입력하지 않습니다.") @RequestParam(required = false) String keyword
     ) {
-        return noteService.getNoteList(userPrincipal, userId);
+        return noteService.getNoteList(userPrincipal, userId, keyword);
     }
+
 }

--- a/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
+++ b/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
@@ -5,9 +5,11 @@ import com.nookbook.domain.book.dto.response.BookStatisticsRes;
 import com.nookbook.domain.book.dto.response.MostReadCategoriesRes;
 import com.nookbook.domain.note.application.NoteService;
 import com.nookbook.domain.note.dto.response.OtherUserNoteListRes;
+import com.nookbook.domain.user.application.FriendService;
 import com.nookbook.domain.user.application.UserService;
 import com.nookbook.domain.user.dto.request.NicknameCheckReq;
 import com.nookbook.domain.user.dto.request.NicknameIdCheckReq;
+import com.nookbook.domain.user.dto.response.SearchUserRes;
 import com.nookbook.domain.user.dto.response.UserInfoRes;
 import com.nookbook.global.config.security.token.CurrentUser;
 import com.nookbook.global.config.security.token.UserPrincipal;
@@ -31,12 +33,13 @@ import java.util.Optional;
 @Tag(name = "User MyPage", description = "User MyPage API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/mypage")
+@RequestMapping("/api/v1/my-page")
 public class MyPageController {
 
     private final UserService userService;
     private final BookService bookService;
     private final NoteService noteService;
+    private final FriendService friendService;
 
     @Operation(summary = "[마이페이지] 사용자 아이디 변경", description = "사용자의 아이디를 변경합니다.")
     @ApiResponses(value = {
@@ -123,13 +126,39 @@ public class MyPageController {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = OtherUserNoteListRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @GetMapping("/note/{userId}")
+    @GetMapping("/friend/{userId}/note")
     public ResponseEntity<?> findUserAllNotes(
             @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.") @PathVariable Long userId,
             @Parameter(description = "검색하고자 하는 단어를 입력해주세요. 없다면 입력하지 않습니다.") @RequestParam(required = false) String keyword
     ) {
         return noteService.getNoteList(userPrincipal, userId, keyword);
+    }
+
+    @Operation(summary = "친구 추가 - 검색", description = "사용자 전체를 대상으로 단어를 검색하여 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = SearchUserRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping("/friend/all")
+    public ResponseEntity<?> searchAllUsers(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "검색하고자 하는 단어를 입력해주세요.") @RequestParam String keyword
+    ) {
+        return friendService.searchUsers(userPrincipal, false, keyword);
+    }
+
+    @Operation(summary = "친구 목록 조회 및 검색", description = "친구 목록을 조회하거나 검색하여 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = SearchUserRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping("/friend")
+    public ResponseEntity<?> searchFriends(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "검색하고자 하는 단어를 입력해주세요. 없다면 입력하지 않습니다.") @RequestParam(required = false) String keyword
+    ) {
+        return friendService.searchUsers(userPrincipal, true, keyword);
     }
 
 }

--- a/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
+++ b/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
@@ -127,7 +127,7 @@ public class MyPageController {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = OtherUserNoteListRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @GetMapping("/friend/{userId}/note")
+    @GetMapping("/{userId}/note")
     public ResponseEntity<?> findUserAllNotes(
             @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.") @PathVariable Long userId,
@@ -185,6 +185,46 @@ public class MyPageController {
             @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.") @PathVariable Long userId
     ) {
         return friendService.sendFriendRequest(userPrincipal, userId);
+    }
+
+    @Operation(summary = "친구 수락/거절", description = "요청을 수락하거나 거절합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @PutMapping("/friend/{friendId}")
+    public ResponseEntity<?> acceptOrRejectFriendRequest(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "친구 요청 목록에서 조회한 friendId를 입력해주세요.") @PathVariable Long friendId,
+            @Parameter(description = "요청의 수락 여부입니다. true: 수락, false: 거절") @RequestParam boolean isAccept
+    ) {
+        return friendService.updateFriendRequestStatus(userPrincipal, friendId, isAccept);
+    }
+
+    @Operation(summary = "친구 요청 취소", description = "내가 보낸 친구 요청을 취소합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "취소 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "취소 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @DeleteMapping ("/friend/pending/{friendId}")
+    public ResponseEntity<?> cancelFriendRequest(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "친구 요청 목록에서 조회한 friendId를 입력해주세요.") @PathVariable Long friendId
+    ) {
+        return friendService.deleteFriendRequest(userPrincipal, friendId, false);
+    }
+
+    @Operation(summary = "친구 삭제", description = "친구를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "삭제 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "삭제 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @DeleteMapping ("/friend/{friendId}")
+    public ResponseEntity<?> deleteFriendRequest(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "친구 목록에서 조회한 friendId를 입력해주세요.") @PathVariable Long friendId
+    ) {
+        return friendService.deleteFriendRequest(userPrincipal, friendId, true);
     }
 
 }

--- a/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
+++ b/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
@@ -3,10 +3,12 @@ package com.nookbook.domain.user.presentation;
 import com.nookbook.domain.book.applicaiton.BookService;
 import com.nookbook.domain.book.dto.response.BookStatisticsRes;
 import com.nookbook.domain.book.dto.response.MostReadCategoriesRes;
+import com.nookbook.domain.note.application.NoteService;
+import com.nookbook.domain.note.dto.response.OtherUserNoteListRes;
 import com.nookbook.domain.user.application.UserService;
 import com.nookbook.domain.user.dto.request.NicknameCheckReq;
 import com.nookbook.domain.user.dto.request.NicknameIdCheckReq;
-import com.nookbook.domain.user.dto.response.MyInfoRes;
+import com.nookbook.domain.user.dto.response.UserInfoRes;
 import com.nookbook.global.config.security.token.CurrentUser;
 import com.nookbook.global.config.security.token.UserPrincipal;
 import com.nookbook.global.payload.ErrorResponse;
@@ -34,6 +36,7 @@ public class MyPageController {
 
     private final UserService userService;
     private final BookService bookService;
+    private final NoteService noteService;
 
     @Operation(summary = "[마이페이지] 사용자 아이디 변경", description = "사용자의 아이디를 변경합니다.")
     @ApiResponses(value = {
@@ -75,40 +78,56 @@ public class MyPageController {
         return userService.updateImage(userPrincipal, isDefaultImage, image);
     }
 
-    @Operation(summary = "[마이페이지] 독서 통계(카테고리별)", description = "마이페이지의 독서 통계(카테고리)를 조회합니다.")
+    @Operation(summary = "[마이페이지] 독서 통계(카테고리별)", description = "마이페이지 또는 친구페이지의 독서 통계(카테고리)를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = MostReadCategoriesRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @GetMapping("/report/category")
+    @GetMapping("/report/category/{userId}")
     public ResponseEntity<?> findReadingReportByCategory(
-            @CurrentUser UserPrincipal userPrincipal
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "독서 통계(카테고리별)을 조회하고자 하는 사용자의 id를 입력해주세요.") @PathVariable Long userId
     ) {
-        return bookService.countReadBooksByCategory(userPrincipal);
+        return bookService.countReadBooksByCategory(userPrincipal, userId);
     }
 
-    @Operation(summary = "[마이페이지] 독서 통계(연도 및 월별)", description = "마이페이지의 독서 통계(연도 및 월별)를 조회합니다.")
+    @Operation(summary = "[마이페이지] 독서 통계(연도 및 월별)", description = "마이페이지 또는 친구페이지의 독서 통계(연도 및 월별)를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = BookStatisticsRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @GetMapping("/report")
+    @GetMapping("/report/{userId}")
     public ResponseEntity<?> findReadingReportByYear(
             @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "독서 통계(연도 및 월별)을 조회하고자 하는 사용자의 id를 입력해주세요.") @PathVariable Long userId,
             @Parameter(description = "독서 통계를 확인하려는 연도를 입력해주세요", required = true) @RequestParam int year
     ) {
-        return bookService.countReadBooksByYear(userPrincipal, year);
+        return bookService.countReadBooksByYear(userPrincipal, userId, year);
     }
 
-    @Operation(summary = "[마이페이지] 내 정보 조회", description = "마이페이지의 내 정보(아이디, 닉네임, 프로필 이미지, 친구 수)를 조회합니다.")
+    @Operation(summary = "[마이페이지] 내 정보 조회", description = "마이페이지 또는 친구페이지의 정보(아이디, 닉네임, 프로필 이미지, 친구 수)를 조회합니다. 친구의 페이지인 경우 친구 상태를 추가하여 반환합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = MyInfoRes.class) ) } ),
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = UserInfoRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @GetMapping
+    @GetMapping("/{userId}")
     public ResponseEntity<?> findMyInformation(
-            @CurrentUser UserPrincipal userPrincipal
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.") @PathVariable Long userId
     ) {
-        return userService.getMyInfo(userPrincipal);
+        return userService.getMyInfo(userPrincipal, userId);
+    }
+
+    @Operation(summary = "[마이페이지] 기록 전체보기 목록 조회", description = "친구페이지의 기록 전체보기 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = OtherUserNoteListRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping("/note/{userId}")
+    public ResponseEntity<?> findUserAllNotes(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.") @PathVariable Long userId
+    ) {
+        return noteService.getNoteList(userPrincipal, userId);
     }
 }

--- a/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
+++ b/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
@@ -9,6 +9,7 @@ import com.nookbook.domain.user.application.FriendService;
 import com.nookbook.domain.user.application.UserService;
 import com.nookbook.domain.user.dto.request.NicknameCheckReq;
 import com.nookbook.domain.user.dto.request.NicknameIdCheckReq;
+import com.nookbook.domain.user.dto.response.FriendsRequestRes;
 import com.nookbook.domain.user.dto.response.SearchUserRes;
 import com.nookbook.domain.user.dto.response.UserInfoRes;
 import com.nookbook.global.config.security.token.CurrentUser;
@@ -148,7 +149,7 @@ public class MyPageController {
         return friendService.searchUsers(userPrincipal, false, keyword);
     }
 
-    @Operation(summary = "친구 목록 조회 및 검색", description = "친구 목록을 조회하거나 검색하여 조회합니다.")
+    @Operation(summary = "친구 목록 - 조회 및 검색", description = "친구 목록을 조회하거나 검색하여 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = SearchUserRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
@@ -159,6 +160,31 @@ public class MyPageController {
             @Parameter(description = "검색하고자 하는 단어를 입력해주세요. 없다면 입력하지 않습니다.") @RequestParam(required = false) String keyword
     ) {
         return friendService.searchUsers(userPrincipal, true, keyword);
+    }
+
+    @Operation(summary = "친구 추가 - 내가 보낸/받은 요청 목록 조회", description = "내가 보낸/받은 요청 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = FriendsRequestRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping("/friend/pending")
+    public ResponseEntity<?> getFriendsRequest(
+            @CurrentUser UserPrincipal userPrincipal
+    ) {
+        return friendService.getFriendRequestList(userPrincipal);
+    }
+
+    @Operation(summary = "친구 요청", description = "다른 사용자에게 친구를 요청합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @PostMapping("/friend/{userId}")
+    public ResponseEntity<?> sendFriendRequest(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.") @PathVariable Long userId
+    ) {
+        return friendService.sendFriendRequest(userPrincipal, userId);
     }
 
 }

--- a/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
+++ b/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
@@ -83,10 +83,10 @@ public class MyPageController {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = MostReadCategoriesRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @GetMapping("/report/category/{userId}")
+    @GetMapping("/report/category")
     public ResponseEntity<?> findReadingReportByCategory(
             @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "독서 통계(카테고리별)을 조회하고자 하는 사용자의 id를 입력해주세요.") @PathVariable Long userId
+            @Parameter(description = "독서 통계(카테고리별)을 조회하고자 하는 사용자의 id를 입력해주세요. 내 통계인 경우 userId는 null로 전달합니다.") @RequestParam(required = false) Long userId
     ) {
         return bookService.countReadBooksByCategory(userPrincipal, userId);
     }
@@ -96,26 +96,26 @@ public class MyPageController {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = BookStatisticsRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @GetMapping("/report/{userId}")
+    @GetMapping("/report")
     public ResponseEntity<?> findReadingReportByYear(
             @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "독서 통계(연도 및 월별)을 조회하고자 하는 사용자의 id를 입력해주세요.") @PathVariable Long userId,
+            @Parameter(description = "독서 통계(연도 및 월별)을 조회하고자 하는 사용자의 id를 입력해주세요. 내 통계인 경우 userId는 null로 전달합니다.") @RequestParam(required = false) Long userId,
             @Parameter(description = "독서 통계를 확인하려는 연도를 입력해주세요", required = true) @RequestParam int year
     ) {
         return bookService.countReadBooksByYear(userPrincipal, userId, year);
     }
 
-    @Operation(summary = "[마이페이지] 내 정보 조회", description = "마이페이지 또는 친구페이지의 정보(아이디, 닉네임, 프로필 이미지, 친구 수)를 조회합니다. 친구의 페이지인 경우 친구 상태를 추가하여 반환합니다.")
+    @Operation(summary = "[마이페이지] 정보 조회", description = "마이페이지 또는 친구페이지의 정보(아이디, 닉네임, 프로필 이미지, 친구 수)를 조회합니다. 친구의 페이지인 경우 친구 상태를 추가하여 반환합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = UserInfoRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @GetMapping("/{userId}")
-    public ResponseEntity<?> findMyInformation(
+    @GetMapping("")
+    public ResponseEntity<?> findUserInformation(
             @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.") @PathVariable Long userId
+            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요. 나의 프로필인 경우 userId는 null로 전달합니다.") @RequestParam(required = false) Long userId
     ) {
-        return userService.getMyInfo(userPrincipal, userId);
+        return userService.getUserInfo(userPrincipal, userId);
     }
 
     @Operation(summary = "[마이페이지] 기록 전체보기 목록 조회", description = "친구페이지의 기록 전체보기 목록을 조회합니다.")

--- a/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
+++ b/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
@@ -179,7 +179,7 @@ public class MyPageController {
             @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
             @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @PostMapping("/friend/{userId}")
+    @PostMapping("/friend/pending/{userId}")
     public ResponseEntity<?> sendFriendRequest(
             @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.") @PathVariable Long userId
@@ -192,7 +192,7 @@ public class MyPageController {
             @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
             @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @PutMapping("/friend/{friendId}")
+    @PutMapping("/friend/pending/{friendId}")
     public ResponseEntity<?> acceptOrRejectFriendRequest(
             @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "친구 요청 목록에서 조회한 friendId를 입력해주세요.") @PathVariable Long friendId,

--- a/src/main/java/com/nookbook/domain/user_book/domain/repository/UserBookRepository.java
+++ b/src/main/java/com/nookbook/domain/user_book/domain/repository/UserBookRepository.java
@@ -6,6 +6,7 @@ import com.nookbook.domain.user_book.domain.BookStatus;
 import com.nookbook.domain.user_book.domain.UserBook;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -22,9 +23,12 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
             "AND FUNCTION('YEAR', ub.updatedAt) = :year")
     List<UserBook> findUserBooksByStatusAndYear(User user, BookStatus bookStatus, int year);
 
-
     //가장 최근에 수정된 UserBook
     UserBook findFirstByUserOrderByUpdatedAtDesc(User user);
 
     List<UserBook> findByUser(User user);
+
+    @Query("SELECT ub FROM UserBook ub JOIN ub.book b WHERE ub.user = :user AND b.title LIKE %:keyword%")
+    List<UserBook> findByUserAndBookTitleLike(@Param("user") User user, @Param("keyword") String keyword);
+
 }

--- a/src/main/java/com/nookbook/domain/user_book/domain/repository/UserBookRepository.java
+++ b/src/main/java/com/nookbook/domain/user_book/domain/repository/UserBookRepository.java
@@ -25,4 +25,6 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
 
     //가장 최근에 수정된 UserBook
     UserBook findFirstByUserOrderByUpdatedAtDesc(User user);
+
+    List<UserBook> findByUser(User user);
 }


### PR DESCRIPTION
## 👑 Summary
> 어떤 내용의 PR인가요?
- #90 자세한 목록은 해당 이슈 참고부탁드립니다! 마이페이지 - 친구페이지 관련 기능 구현했습니다.

## 🫧 To be noted
> PR을 검토할 때 확인해야 할 사항이 있나요?
- `Friend` 테이블을 추가했습니다. 해당 테이블에는 `sender`와 `receiver`그리고 친구 요청 상태인 `friendRequestStatus` 가 있습니다. 현재 친구 상태인지, 친구 요청 상태인지 모두 해당 테이블에서 구별합니다. 관련 기능 구현 시 참고해주세요!
- 타인의 프로필 조회 기능을 위해 mypage 기능(내 정보 조회, 독서통계)을 수정했습니다.

## 💫 issue number
> 이슈 번호를 작성해주새요
- resolve #90 

## ☑️ Checklist
> PR 요청 시 체크해주세요.
- [x] label
- [x] issue number
- [x] conflict resolve

## 💡 Comment
> 전달하고 싶은 내용이 있나요?
- 도서 테이블에 출판사 컬럼이 없어 추가했습니다.
- 저는 마이페이지 내에 있는 친구 기능만을 구현했으니 @EunbeenDev **챌린지 구현 시 친구 관련 부분도 같이 구현**해주시고, 마이페이지 보시면 **친구의 프로필 조회 시 컬렉션 목록**을 볼 수가 있더라고요! 해당 부분 참고해서 개발해주세용