### PR TITLE
[FEAT] 챌린지 내 친구 관련 기능 구현

### DIFF
--- a/src/main/java/com/nookbook/domain/challenge/application/ChallengeService.java
+++ b/src/main/java/com/nookbook/domain/challenge/application/ChallengeService.java
@@ -3,9 +3,7 @@ package com.nookbook.domain.challenge.application;
 import com.nookbook.domain.book.BookNotFoundException;
 import com.nookbook.domain.book.domain.Book;
 import com.nookbook.domain.book.domain.repository.BookRepository;
-import com.nookbook.domain.challenge.domain.Challenge;
-import com.nookbook.domain.challenge.domain.ChallengeStatus;
-import com.nookbook.domain.challenge.domain.Participant;
+import com.nookbook.domain.challenge.domain.*;
 import com.nookbook.domain.challenge.domain.repository.ChallengeRepository;
 import com.nookbook.domain.challenge.domain.repository.InvitationRepository;
 import com.nookbook.domain.challenge.domain.repository.ParticipantRepository;
@@ -15,6 +13,8 @@ import com.nookbook.domain.challenge.exception.ChallengeNotAuthorizedException;
 import com.nookbook.domain.challenge.exception.ChallengeNotFoundException;
 import com.nookbook.domain.challenge.exception.ParticipantNotFoundException;
 import com.nookbook.domain.challenge.exception.ParticipantNotInChallengeException;
+import com.nookbook.domain.user.application.FriendService;
+import com.nookbook.domain.user.domain.Friend;
 import com.nookbook.infrastructure.s3.S3Uploader;
 import com.nookbook.domain.user.application.UserService;
 import com.nookbook.domain.user.domain.User;
@@ -50,6 +50,7 @@ public class ChallengeService {
     private final UserBookRepository userBookRepository;
     private final BookRepository bookRepository;
     private final UserRepository userRepository;
+    private final FriendService friendService;
 
     // 챌린지 생성
     @Transactional
@@ -131,6 +132,13 @@ public class ChallengeService {
                 .filter(challenge -> challenge.getChallengeStatus().equals(ChallengeStatus.END))
                 .toList();
 
+        // 초대 수락 대기중인 챌린지 목록
+        List<Invitation> invitations = invitationRepository.findAllByUser(user);
+        List<Challenge> waitingInvitationList = invitations.stream()
+                .filter(invitation -> invitation.getInvitationStatus().equals(InvitationStatus.INVITING))
+                .map(Invitation::getChallenge)
+                .toList();
+
         ChallengeListRes challengeListRes = ChallengeListRes.builder()
                 .waitingCount(waitingChallengeList.size())
                 .waitingList(
@@ -155,6 +163,16 @@ public class ChallengeService {
                 .endCount(endChallengeList.size())
                 .endList(
                         endChallengeList.stream()
+                                .map(challenge -> ChallengeListDetailRes.builder()
+                                        .challengeId(challenge.getChallengeId())
+                                        .title(challenge.getTitle())
+                                        .challengeCover(challenge.getChallengeCover())
+                                        .build())
+                                .toList()
+                )
+                .waitingInvitationCount(waitingInvitationList.size())
+                .waitingInvitationList(
+                        waitingInvitationList.stream()
                                 .map(challenge -> ChallengeListDetailRes.builder()
                                         .challengeId(challenge.getChallengeId())
                                         .title(challenge.getTitle())
@@ -259,14 +277,16 @@ public class ChallengeService {
         User user = validateUser(userPrincipal);
         User participant = userRepository.findById(participantId)
                 .orElseThrow(UserNotFoundException::new);
+
         Challenge challenge = validateChallenge(challengeId);
+
         validateChallengeAuthorization(user, challenge); // 챌린지 owner만 참가자 초대 가능
-        // 챌린지 참가자 추가
+        // 챌린지 참가자 초대
         invitationService.inviteParticipant(challenge, participant);
 
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)
-                .information("참가자 추가가 완료되었습니다.")
+                .information("참가 요청이 완료되었습니다.")
                 .build();
 
         return ResponseEntity.ok(apiResponse);
@@ -392,6 +412,97 @@ public class ChallengeService {
         return ResponseEntity.ok(apiResponse);
     }
 
+
+    public ResponseEntity<?> getInviteFriends(UserPrincipal userPrincipal, Long challengeId) {
+        User user = validateUser(userPrincipal);
+        Challenge challenge = validateChallenge(challengeId);
+
+        // 사용자의 친구 목록 (accept 상태) 조회
+        List<Friend> friends = friendService.getFriends(user);
+
+        // 전체 친구 목록 - 이미 참가중인 친구 제외
+        List<Friend> inviteFriends = friends.stream()
+                .filter(friend -> !participantRepository.existsByUserUserIdAndChallenge(friend.getFriendId(), challenge))
+                .toList();
+
+        // 해당 챌린지의 invitation 목록 조회
+        List<Invitation> invitations = invitationRepository.findAllByChallenge(challenge);
+
+        List<ChallengeInvitationRes> challengeInvitationResList = inviteFriends.stream()
+                .map(friend -> {
+                    Long friendUserId = friend.getFriendUserId(user);  // 친구의 userId 가져오기
+                    return ChallengeInvitationRes.builder()
+                            .userId(friendUserId)
+                            .nickname(userService.findById(friendUserId).getNickname())  // userId로 닉네임 조회
+                            .isInvitable(invitations.stream()
+                            .noneMatch(invitation -> invitation.getUser().getUserId().equals(friendUserId)))
+                            .build();
+                })
+                .toList();
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(challengeInvitationResList)
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @Transactional
+    public ResponseEntity<?> acceptInvitation(UserPrincipal userPrincipal, Long challengeId) {
+        User user = validateUser(userPrincipal);
+        Challenge challenge = validateChallenge(challengeId);
+
+        // 해당 챌린지의 invitation 목록 조회
+        List<Invitation> invitations = invitationRepository.findAllByChallenge(challenge);
+
+        // 해당 유저의 invitation 찾기
+        Invitation invitation = invitations.stream()
+                .filter(inv -> inv.getUser().equals(user))
+                .findFirst()
+                .orElseThrow();
+
+        // 초대 수락
+        invitationService.acceptInvitation(invitation.getInvitationId());
+
+        // 챌린지 참가자(participant)로 등록
+        participantService.saveParticipant(user, challenge);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information("챌린지 참가가 완료되었습니다.")
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+
+    }
+
+    @Transactional
+    public ResponseEntity<?> rejectInvitation(UserPrincipal userPrincipal, Long challengeId) {
+        User user = validateUser(userPrincipal);
+        Challenge challenge = validateChallenge(challengeId);
+
+        // 해당 챌린지의 invitation 목록 조회
+        List<Invitation> invitations = invitationRepository.findAllByChallenge(challenge);
+
+        // 해당 유저의 invitation 찾기
+        Invitation invitation = invitations.stream()
+                .filter(inv -> inv.getUser().equals(user))
+                .findFirst()
+                .orElseThrow();
+
+        // 초대 거절
+        invitationService.rejectInvitation(invitation.getInvitationId());
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information("챌린지 참가 요청을 거절하였습니다.")
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
+
     // 사용자 검증 메서드
     private User validateUser(UserPrincipal userPrincipal) {
 //        return userService.findByEmail(userPrincipal.getEmail())
@@ -431,5 +542,6 @@ public class ChallengeService {
         return bookRepository.findById(bookId)
                 .orElseThrow(BookNotFoundException::new);
     }
+
 
 }

--- a/src/main/java/com/nookbook/domain/challenge/application/InvitationService.java
+++ b/src/main/java/com/nookbook/domain/challenge/application/InvitationService.java
@@ -2,6 +2,7 @@ package com.nookbook.domain.challenge.application;
 
 import com.nookbook.domain.challenge.domain.Challenge;
 import com.nookbook.domain.challenge.domain.Invitation;
+import com.nookbook.domain.challenge.domain.InvitationStatus;
 import com.nookbook.domain.challenge.domain.repository.InvitationRepository;
 import com.nookbook.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class InvitationService {
     private final InvitationRepository invitationRepository;
 
+
+
+    @Transactional
     public void inviteParticipant(Challenge challenge, User participant) {
         Invitation invitation = Invitation.builder()
                 .challenge(challenge)
@@ -21,6 +25,22 @@ public class InvitationService {
                 .build();
 
         invitationRepository.save(invitation);
+    }
+
+    // 초대 수락
+    @Transactional
+    public void acceptInvitation(Long invitationId) {
+        Invitation invitation = invitationRepository.findById(invitationId).orElseThrow();
+        invitation.updateInvitationStatus(InvitationStatus.ACCEPT);
+        // Invitation 삭제
+        invitationRepository.delete(invitation);
+    }
+
+    // 초대 거절
+    @Transactional
+    public void rejectInvitation(Long invitationId) {
+        Invitation invitation = invitationRepository.findById(invitationId).orElseThrow();
+        invitation.updateInvitationStatus(InvitationStatus.REJECT);
     }
 
 }

--- a/src/main/java/com/nookbook/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/nookbook/domain/challenge/domain/Challenge.java
@@ -56,7 +56,6 @@ public class Challenge extends BaseEntity {
     private User owner;
 
 
-
     @Builder
     public Challenge(String title, String challengeCover, LocalDate startDate, LocalDate endDate, Integer dailyGoal, LocalTime startTime, LocalTime endTime, ChallengeStatus challengeStatus, List<Participant> participants, User owner) {
         this.title = title;

--- a/src/main/java/com/nookbook/domain/challenge/domain/Invitation.java
+++ b/src/main/java/com/nookbook/domain/challenge/domain/Invitation.java
@@ -26,10 +26,19 @@ public class Invitation extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Enumerated(EnumType.STRING)
+    private InvitationStatus invitationStatus;
+
     @Builder
     public Invitation(Challenge challenge, User user) {
         this.challenge = challenge;
         this.user = user;
+        this.invitationStatus = InvitationStatus.INVITING;
+    }
+
+    // invitation status 변경
+    public void updateInvitationStatus(InvitationStatus invitationStatus) {
+        this.invitationStatus = invitationStatus;
     }
 
 }

--- a/src/main/java/com/nookbook/domain/challenge/domain/InvitationStatus.java
+++ b/src/main/java/com/nookbook/domain/challenge/domain/InvitationStatus.java
@@ -1,0 +1,10 @@
+package com.nookbook.domain.challenge.domain;
+
+public enum InvitationStatus {
+    // 초대중
+    INVITING,
+    // 수락
+    ACCEPT,
+    // 거절
+    REJECT
+}

--- a/src/main/java/com/nookbook/domain/challenge/domain/repository/InvitationRepository.java
+++ b/src/main/java/com/nookbook/domain/challenge/domain/repository/InvitationRepository.java
@@ -1,9 +1,16 @@
 package com.nookbook.domain.challenge.domain.repository;
 
+import com.nookbook.domain.challenge.domain.Challenge;
 import com.nookbook.domain.challenge.domain.Invitation;
+import com.nookbook.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface InvitationRepository extends JpaRepository<Invitation, Long> {
+    List<Invitation> findAllByChallenge(Challenge challenge);
+
+    List<Invitation> findAllByUser(User user);
 }

--- a/src/main/java/com/nookbook/domain/challenge/domain/repository/ParticipantRepository.java
+++ b/src/main/java/com/nookbook/domain/challenge/domain/repository/ParticipantRepository.java
@@ -3,6 +3,7 @@ package com.nookbook.domain.challenge.domain.repository;
 import com.nookbook.domain.challenge.domain.Challenge;
 import com.nookbook.domain.challenge.domain.Participant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,4 +11,10 @@ import java.util.List;
 @Repository
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
     List<Participant> findAllByChallenge(Challenge challenge);
+
+    @Query("select p from Participant p where p.user.userId = :friendId and p.challenge = :challenge")
+    boolean existsByUserAndChallenge(Long friendId, Challenge challenge);
+
+    boolean existsByUserUserIdAndChallenge(Long friendId, Challenge challenge);
+
 }

--- a/src/main/java/com/nookbook/domain/challenge/dto/response/ChallengeInvitationRes.java
+++ b/src/main/java/com/nookbook/domain/challenge/dto/response/ChallengeInvitationRes.java
@@ -1,0 +1,22 @@
+package com.nookbook.domain.challenge.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ChallengeInvitationRes {
+    @Schema(type = "Long", example = "1", description = "친구의 userId")
+    private Long userId;
+
+    @Schema(type = "String", example = "야옹아멍멍해바", description = "친구의 닉네임")
+    private String nickname;
+
+    @Schema(type = "boolean", example = "true", description = "초대 가능 여부")
+    private boolean isInvitable;
+}

--- a/src/main/java/com/nookbook/domain/challenge/dto/response/ChallengeListRes.java
+++ b/src/main/java/com/nookbook/domain/challenge/dto/response/ChallengeListRes.java
@@ -32,4 +32,12 @@ public class ChallengeListRes {
     @Schema(type = "List", description = "종료된 챌린지 목록")
     private List<ChallengeListDetailRes> endList;
 
+    @Schema(type = "Long", example = "1", description = "초대 수락 대기중인 챌린지 수")
+    // waitingInvitationCount
+    private int waitingInvitationCount;
+
+    @Schema(type = "List", description = "초대 수락 대기중인 챌린지 목록")
+    // waitingInvitationList
+    private List<ChallengeListDetailRes> waitingInvitationList;
+
 }

--- a/src/main/java/com/nookbook/domain/challenge/presentation/ChallengeController.java
+++ b/src/main/java/com/nookbook/domain/challenge/presentation/ChallengeController.java
@@ -3,6 +3,7 @@ package com.nookbook.domain.challenge.presentation;
 import com.nookbook.domain.challenge.application.ChallengeService;
 import com.nookbook.domain.challenge.dto.request.ChallengeCreateReq;
 import com.nookbook.domain.challenge.dto.response.ChallengeDetailRes;
+import com.nookbook.domain.challenge.dto.response.ChallengeInvitationRes;
 import com.nookbook.domain.challenge.dto.response.ChallengeListRes;
 import com.nookbook.domain.challenge.dto.response.ParticipantListRes;
 import com.nookbook.global.config.security.token.CurrentUser;
@@ -86,7 +87,7 @@ public class ChallengeController {
         return challengeService.deleteParticipant(userPrincipal, challengeId, participantId);
     }
 
-    // 챌린지 참가자 추가 API
+    // 챌린지 참가 요청(초대) API
     @Operation(summary = "챌린지 참가자 초대 요청 API", description = "챌린지에 참가자를 초대하는 API입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "챌린지 참가자 초대 요청 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}),
@@ -174,4 +175,45 @@ public class ChallengeController {
         return challengeService.getParticipantList(userPrincipal, challengeId);
     }
 
+    // 챌린지에 초대할 친구 목록 조회 API
+    @Operation(summary = "챌린지에 초대할 친구 목록 조회 API", description = "챌린지에 초대할 친구 목록을 조회하는 API입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "챌린지에 초대할 친구 목록 조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(type = "array", implementation = ChallengeInvitationRes.class))}),
+            @ApiResponse(responseCode = "400", description = "챌린지에 초대할 친구 목록 조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @GetMapping("/{challengeId}/invite")
+    public ResponseEntity<?> getInviteFriends(
+            @Parameter @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "챌린지 ID") @PathVariable Long challengeId
+    ) {
+        return challengeService.getInviteFriends(userPrincipal, challengeId);
+    }
+
+    // 챌린지 초대 수락 API
+    @Operation(summary = "챌린지 초대 수락 API", description = "챌린지 초대를 수락하는 API입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "챌린지 초대 수락 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}),
+            @ApiResponse(responseCode = "400", description = "챌린지 초대 수락 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @PostMapping("/{challengeId}/accept")
+    public ResponseEntity<?> acceptInvitation(
+            @Parameter @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "챌린지 ID") @PathVariable Long challengeId
+    ) {
+        return challengeService.acceptInvitation(userPrincipal, challengeId);
+    }
+
+    // 챌린지 초대 거절 API
+    @Operation(summary = "챌린지 초대 거절 API", description = "챌린지 초대를 거절하는 API입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "챌린지 초대 거절 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}),
+            @ApiResponse(responseCode = "400", description = "챌린지 초대 거절 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @PostMapping("/{challengeId}/reject")
+    public ResponseEntity<?> rejectInvitation(
+            @Parameter @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "챌린지 ID") @PathVariable Long challengeId
+    ) {
+        return challengeService.rejectInvitation(userPrincipal, challengeId);
+    }
 }

--- a/src/main/java/com/nookbook/domain/challenge/presentation/ChallengeController.java
+++ b/src/main/java/com/nookbook/domain/challenge/presentation/ChallengeController.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -176,17 +177,20 @@ public class ChallengeController {
     }
 
     // 챌린지에 초대할 친구 목록 조회 API
+    // 페이징 처리 필요
     @Operation(summary = "챌린지에 초대할 친구 목록 조회 API", description = "챌린지에 초대할 친구 목록을 조회하는 API입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "챌린지에 초대할 친구 목록 조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(type = "array", implementation = ChallengeInvitationRes.class))}),
             @ApiResponse(responseCode = "400", description = "챌린지에 초대할 친구 목록 조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
     })
     @GetMapping("/{challengeId}/invite")
-    public ResponseEntity<?> getInviteFriends(
+    public Page<ChallengeInvitationRes> getInviteFriends(
             @Parameter @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "챌린지 ID") @PathVariable Long challengeId
+            @Parameter(description = "챌린지 ID") @PathVariable Long challengeId,
+            @Parameter(description = "목록의 페이지 번호를 입력해주세요. **Page는 0부터 시작됩니다!**", required = true)
+            @RequestParam(value = "page", required = false, defaultValue = "0") Integer page
     ) {
-        return challengeService.getInviteFriends(userPrincipal, challengeId);
+        return challengeService.getInviteFriends(userPrincipal, challengeId, page);
     }
 
     // 챌린지 초대 수락 API

--- a/src/main/java/com/nookbook/domain/user/application/FriendService.java
+++ b/src/main/java/com/nookbook/domain/user/application/FriendService.java
@@ -148,6 +148,13 @@ public class FriendService {
                 .build());
     }
 
+
+    // 사용자의 친구 목록 조회
+    public List<Friend> getFriends(User user) {
+        // User user = validUserByUserId(userPrincipal.getId());
+        return friendRepository.findAcceptedFriends(user);
+    }
+
     private User validUserByUserId(Long userId) {
         Optional<User> user = userRepository.findById(userId);
         DefaultAssert.isTrue(user.isPresent(), "사용자가 존재하지 않습니다.");

--- a/src/main/java/com/nookbook/domain/user/application/FriendService.java
+++ b/src/main/java/com/nookbook/domain/user/application/FriendService.java
@@ -11,6 +11,8 @@ import com.nookbook.global.DefaultAssert;
 import com.nookbook.global.config.security.token.UserPrincipal;
 import com.nookbook.global.payload.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -150,9 +152,9 @@ public class FriendService {
 
 
     // 사용자의 친구 목록 조회
-    public List<Friend> getFriends(User user) {
+    public Page<Friend> getFriends(User user, Pageable pageable) {
         // User user = validUserByUserId(userPrincipal.getId());
-        return friendRepository.findAcceptedFriends(user);
+        return friendRepository.findAcceptedFriends(user, pageable);
     }
 
     private User validUserByUserId(Long userId) {

--- a/src/main/java/com/nookbook/domain/user/domain/Friend.java
+++ b/src/main/java/com/nookbook/domain/user/domain/Friend.java
@@ -37,4 +37,9 @@ public class Friend extends BaseEntity {
     public void updateFriendRequestStatus(FriendRequestStatus friendRequestStatus) {
         this.friendRequestStatus = friendRequestStatus;
     }
+
+    // 사용자 본인이 아닌 친구의 user id를 가져오는 유틸 메서드
+    public Long getFriendUserId(User currentUser) {
+        return sender.equals(currentUser) ? receiver.getUserId() : sender.getUserId();
+    }
 }

--- a/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
+++ b/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
@@ -3,6 +3,8 @@ package com.nookbook.domain.user.domain.repository;
 import com.nookbook.domain.user.domain.Friend;
 import com.nookbook.domain.user.domain.FriendRequestStatus;
 import com.nookbook.domain.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -51,5 +53,5 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     @Query("SELECT f FROM Friend f " +
             "WHERE (f.sender = :user OR f.receiver = :user) " +
             "AND f.friendRequestStatus = 'FRIEND_ACCEPT'")
-    List<Friend> findAcceptedFriends(@Param("user") User user);
+    Page<Friend> findAcceptedFriends(@Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
+++ b/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
@@ -47,4 +47,9 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
             @Param("friendRequestStatus") FriendRequestStatus friendRequestStatus);
 
 
+    // reciever_id 또는 sender_id가 user이면서, friendRequestStatus가 FRIEND_ACCEPT인 친구 목록 조회
+    @Query("SELECT f FROM Friend f " +
+            "WHERE (f.sender = :user OR f.receiver = :user) " +
+            "AND f.friendRequestStatus = 'FRIEND_ACCEPT'")
+    List<Friend> findAcceptedFriends(@Param("user") User user);
 }


### PR DESCRIPTION
## 👑 Summary
> 어떤 내용의 PR인가요?
- 챌린지 내 친구 관련 기능 구현

## 🫧 To be noted
> PR을 검토할 때 확인해야 할 사항이 있나요?
- 

## 💫 issue number
> 이슈 번호를 작성해주새요
- #84 #86 

## ☑️ Checklist
> PR 요청 시 체크해주세요.
- [ ] label
- [ ] issue number
- [ ] conflict resolve

## 💡 Comment
> 전달하고 싶은 내용이 있나요?
- Friend Entity 내 reciever, sender 중 본인이 아닌 친구의 userId를 return하는 메소드가 추가되었습니다.
- 챌린지 초대 상태(수락 대기/수락/거절)에 대한 도메인이 추가되었습니다.
- 챌린지 초대 시, invitiation 객체가 생성되며, 수락 시에는 invitation 객체가 삭제됩니다.
- 거절 시에 invitation 객체가 남아있는 이유는, 챌린지 초대를 거절한 유저 또한 챌린지 초대 목록에 나타나기 때문입니다.
- 챌린지 초대 시, 거절하거나, 이미 초대장을 보낸 여부를 판단하기 위해 invitable 필드가 존재합니다.