### PR TITLE
[FEAT] 타이머 시작 API 구현

### DIFF
--- a/src/main/java/com/nookbook/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nookbook/domain/book/presentation/BookController.java
@@ -130,17 +130,31 @@ public class BookController {
         return timerService.getTimerRecords(userPrincipal, bookId);
     }
 
-    @Operation(summary = "타이머 기록 저장", description = "타이머 기록을 저장합니다.")
+    @Operation(summary = "타이머 종료", description = "타이머를 종료하고, 타이머 기록을 저장합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = TimerRes.class)) } ),
             @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     } )
-    @PostMapping("/{bookId}/timer")
+    @PostMapping("/{bookId}/timer/{timerId}")
     public ResponseEntity<?> saveTimerRecord(
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "도서의 id를 입력해주세요.", required = true) @PathVariable Long bookId,
+            @Parameter(description = "타이머의 id를 입력해주세요.", required = true) @PathVariable Long timerId,
             @Parameter(description = "시간을 입력해주세요.", required = true) @RequestBody CreateTimerReq createTimerReq
             ) {
-        return timerService.saveTimerRecord(userPrincipal, bookId, createTimerReq);
+        return timerService.saveTimerRecord(userPrincipal, bookId, timerId, createTimerReq);
+    }
+
+    @Operation(summary = "타이머 시작", description = "타이머를 시작합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class)) } ),
+            @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    } )
+    @PostMapping("/{bookId}/timer")
+    public ResponseEntity<?> startTimerRecord(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "도서의 id를 입력해주세요.", required = true) @PathVariable Long bookId
+    ) {
+        return timerService.updateTimerStatus(userPrincipal, bookId);
     }
 }

--- a/src/main/java/com/nookbook/domain/timer/domain/Timer.java
+++ b/src/main/java/com/nookbook/domain/timer/domain/Timer.java
@@ -26,10 +26,22 @@ public class Timer extends BaseEntity {
 
     private BigInteger readTime;
 
+    @Column(name = "is_reading")
+    private boolean isReading;
+
     @Builder
-    public Timer(UserBook userBook, BigInteger readTime) {
+    public Timer(UserBook userBook, BigInteger readTime, boolean isReading) {
         this.userBook = userBook;
         this.readTime = readTime;
+        this.isReading = isReading;
+    }
+
+    public void updateReadTime(BigInteger readTime) {
+        this.readTime = readTime;
+    }
+
+    public void updateIsReading(boolean isReading) {
+        this.isReading = isReading;
     }
 
 }

--- a/src/main/java/com/nookbook/domain/timer/domain/repository/TimerRepository.java
+++ b/src/main/java/com/nookbook/domain/timer/domain/repository/TimerRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TimerRepository extends JpaRepository<Timer, Long> {
@@ -13,5 +14,7 @@ public interface TimerRepository extends JpaRepository<Timer, Long> {
 
     Timer findTop1ByUserBookOrderByCreatedAtAsc(UserBook userBook);
 
-    List<Timer> findByUserBookOrderByCreatedAtDesc(UserBook userBook);
+    List<Timer> findByUserBookAndIsReadingOrderByCreatedAtDesc(UserBook userBook, boolean isReading);
+
+    Optional<Timer> findByUserBookAndIsReading(UserBook userBook, boolean isReading);
 }

--- a/src/main/java/com/nookbook/domain/timer/dto/response/StartTimerIdRes.java
+++ b/src/main/java/com/nookbook/domain/timer/dto/response/StartTimerIdRes.java
@@ -1,0 +1,17 @@
+package com.nookbook.domain.timer.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StartTimerIdRes {
+
+    @Schema(type = "Long", example = "1", description = "타이머의 id입니다.")
+    private Long timerId;
+}

--- a/src/main/java/com/nookbook/domain/timer/dto/response/TimerRes.java
+++ b/src/main/java/com/nookbook/domain/timer/dto/response/TimerRes.java
@@ -1,5 +1,7 @@
 package com.nookbook.domain.timer.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,8 +16,16 @@ import java.util.List;
 @AllArgsConstructor
 public class TimerRes {
 
+    @Schema(type = "boolean", example = "true", description = "타이머 상태입니다. true: 타이머를 켜고 책을 읽는 중, false: 타이머를 끔(읽고있지 않음)")
+    @JsonProperty("isReading")
+    private boolean reading;
+
+    @Schema(type = "Long", example = "1", description = "타이머를 켜둔 상태라면 현재 타이머의 id를 반환합니다. 타이머가 꺼져있다면 전달되지 않습니다.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Long timerId;
+
     @Schema(type = "String", example = "01:20:00", description = "누적 독서 시간입니다. HH:MM:SS 형식입니다.")
-    public String totalReadTime;
+    private String totalReadTime;
 
     @Schema(type = "array", description = "Schemas의 TimerRecordRes를 참고해주세요. 타이머를 이용해 기록된 독서 시간의 리스트입니다.")
     private List<TimerRecordRes> recordResList;

--- a/src/main/java/com/nookbook/domain/user/application/FriendService.java
+++ b/src/main/java/com/nookbook/domain/user/application/FriendService.java
@@ -13,6 +13,7 @@ import com.nookbook.global.payload.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,32 +31,43 @@ public class FriendService {
     private final FriendRepository friendRepository;
 
     // 검색
-    public ResponseEntity<?> searchUsers(UserPrincipal userPrincipal, boolean isFriend, String keyword) {
-        // User user = validUserByUserId(userPrincipal.getId());
+    public ResponseEntity<?> searchUsers(UserPrincipal userPrincipal, boolean isFriend, String keyword, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
         User user = validUserByUserId(1L);
-         List<SearchUserRes> searchUserRes = isFriend ? getFriendsByKeyword(user, keyword) : getAllUsersByKeyword(user, keyword);
+        Page<SearchUserRes> searchUserRes = isFriend
+                ? getFriendsByKeyword(user, keyword, pageable)
+                : getAllUsersByKeyword(user, keyword, pageable);
         return ResponseEntity.ok(ApiResponse.builder()
                 .check(true)
                 .information(searchUserRes)
                 .build());
     }
 
-    private List<SearchUserRes> getAllUsersByKeyword(User user, String keyword) {
-        List<User> findUsers = userRepository.findUsersNotInFriendByKeyword(user, keyword);
-        return findUsers.stream()
-                .map(findUser -> SearchUserRes.builder()
-                        .userId(findUser.getUserId())
-                        .nickname(findUser.getNickname())
-                        .imageUrl(findUser.getImageUrl())
-                        .build())
-                .toList();
+    private Page<SearchUserRes> getAllUsersByKeyword(User user, String keyword, Pageable pageable) {
+        Page<User> findUsers = userRepository.findUsersNotInFriendByKeyword(user, keyword, pageable);
+        return findUsers.map(findUser -> SearchUserRes.builder()
+                .userId(findUser.getUserId())
+                .nickname(findUser.getNickname())
+                .imageUrl(findUser.getImageUrl())
+                .build());
     }
 
-    private List<SearchUserRes> getFriendsByKeyword(User user, String keyword) {
-        List<Friend> findFriends = keyword != null ?
-                friendRepository.findBySenderOrReceiverAndStatusAndNicknameLikeKeyword(user, keyword, FriendRequestStatus.FRIEND_ACCEPT)
-                : friendRepository.findBySenderOrReceiverAndStatus(user, FriendRequestStatus.FRIEND_ACCEPT);
-        return buildSearchUserRes(findFriends, user);
+    private Page<SearchUserRes> getFriendsByKeyword(User user, String keyword, Pageable pageable) {
+        Page<Friend> findFriends = (keyword != null)
+                ? friendRepository.findBySenderOrReceiverAndStatusAndNicknameLikeKeyword(user, keyword, FriendRequestStatus.FRIEND_ACCEPT, pageable)
+                : friendRepository.findBySenderOrReceiverAndStatus(user, FriendRequestStatus.FRIEND_ACCEPT, pageable);
+        return findFriends.map(friend -> {
+            User targetUser = getTargetUser(user, friend);
+            return SearchUserRes.builder()
+                    .userId(targetUser.getUserId())
+                    .nickname(targetUser.getNickname())
+                    .imageUrl(targetUser.getImageUrl())
+                    .build();}
+        );
+    }
+
+    private User getTargetUser(User user, Friend friend) {
+        return user.equals(friend.getSender()) ? friend.getReceiver() : friend.getSender();
     }
 
     @Transactional
@@ -97,7 +109,7 @@ public class FriendService {
     private List<SearchUserRes> buildSearchUserRes(List<Friend> friends, User user) {
         return friends.stream()
                 .map(friend -> {
-                    User targetUser = user == friend.getSender() ? friend.getReceiver() : friend.getSender();
+                    User targetUser = getTargetUser(user, friend);
                     return SearchUserRes.builder()
                             .userId(targetUser.getUserId())
                             .friendId(friend.getFriendId())

--- a/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
+++ b/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
@@ -36,17 +36,19 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
             "    (f.receiver = :user AND (f.sender.nickname LIKE %:keyword% OR f.sender.nicknameId LIKE %:keyword%)) " +
             ") " +
             "AND f.friendRequestStatus = :friendRequestStatus")
-    List<Friend> findBySenderOrReceiverAndStatusAndNicknameLikeKeyword(
+    Page<Friend> findBySenderOrReceiverAndStatusAndNicknameLikeKeyword(
             @Param("user") User user,
             @Param("keyword") String keyword,
-            @Param("friendRequestStatus") FriendRequestStatus friendRequestStatus);
+            @Param("friendRequestStatus") FriendRequestStatus friendRequestStatus,
+            Pageable pageable);
 
     @Query("SELECT f FROM Friend f " +
             "WHERE (f.sender = :user OR f.receiver = :user) " +
             "AND f.friendRequestStatus = :friendRequestStatus")
-    List<Friend> findBySenderOrReceiverAndStatus(
+    Page<Friend> findBySenderOrReceiverAndStatus(
             @Param("user") User user,
-            @Param("friendRequestStatus") FriendRequestStatus friendRequestStatus);
+            @Param("friendRequestStatus") FriendRequestStatus friendRequestStatus,
+            Pageable pageable);
 
 
     // reciever_id 또는 sender_id가 user이면서, friendRequestStatus가 FRIEND_ACCEPT인 친구 목록 조회

--- a/src/main/java/com/nookbook/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/nookbook/domain/user/domain/repository/UserRepository.java
@@ -2,6 +2,8 @@ package com.nookbook.domain.user.domain.repository;
 
 import com.nookbook.domain.user.domain.FriendRequestStatus;
 import com.nookbook.domain.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -26,6 +28,6 @@ public interface UserRepository extends JpaRepository<User, Long>{
             "    WHERE (f.sender = :user AND f.receiver = u) OR (f.receiver = :user AND f.sender = u)" +
             ") " +
             "AND (u.nicknameId LIKE %:keyword% OR u.nickname LIKE %:keyword%)")
-    List<User> findUsersNotInFriendByKeyword(@Param("user") User user, @Param("keyword") String keyword);
+    Page<User> findUsersNotInFriendByKeyword(@Param("user") User user, @Param("keyword") String keyword, Pageable pageable);
 
 }

--- a/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
+++ b/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
@@ -144,9 +144,11 @@ public class MyPageController {
     @GetMapping("/friend/all")
     public ResponseEntity<?> searchAllUsers(
             @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "검색하고자 하는 단어를 입력해주세요.") @RequestParam String keyword
+            @Parameter(description = "검색하고자 하는 단어를 입력해주세요.") @RequestParam String keyword,
+            @Parameter(description = "페이지의 숫자입니다. 페이지는 0부터 시작합니다.") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 내 요소의 개수입니다.") @RequestParam(defaultValue = "20") int size
     ) {
-        return friendService.searchUsers(userPrincipal, false, keyword);
+        return friendService.searchUsers(userPrincipal, false, keyword, page, size);
     }
 
     @Operation(summary = "친구 목록 - 조회 및 검색", description = "친구 목록을 조회하거나 검색하여 조회합니다.")
@@ -157,9 +159,11 @@ public class MyPageController {
     @GetMapping("/friend")
     public ResponseEntity<?> searchFriends(
             @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "검색하고자 하는 단어를 입력해주세요. 없다면 입력하지 않습니다.") @RequestParam(required = false) String keyword
+            @Parameter(description = "검색하고자 하는 단어를 입력해주세요. 없다면 입력하지 않습니다.") @RequestParam(required = false) String keyword,
+            @Parameter(description = "페이지의 숫자입니다. 페이지는 0부터 시작합니다.") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 내 요소의 개수입니다.") @RequestParam(defaultValue = "20") int size
     ) {
-        return friendService.searchUsers(userPrincipal, true, keyword);
+        return friendService.searchUsers(userPrincipal, true, keyword, page, size);
     }
 
     @Operation(summary = "친구 추가 - 내가 보낸/받은 요청 목록 조회", description = "내가 보낸/받은 요청 목록을 조회합니다.")


### PR DESCRIPTION
## 👑 Summary
> 어떤 내용의 PR인가요?
- 타이머 시작 시 호출되는 API 구현 및 연관된 기능 일괄 수정(타이머 조회, 타이머 저장)
- 친구 목록 조회&검색, 전체 사용자 검색 시 페이징 추가

## 🫧 To be noted
> PR을 검토할 때 확인해야 할 사항이 있나요?
- 타이머 테이블에 `isReading` 컬럼을 추가했습니다. 타이머 시작 API에서 해당 상태를 true로 변경하고, 저장(종료) 시 false로 변경합니다.
-  친구 목록 조회 시 페이징 추가했는데, 챌린지 부분이랑 동일하게 size 20으로 설정했습니다.

## 💫 issue number
> 이슈 번호를 작성해주새요
-

## ☑️ Checklist
> PR 요청 시 체크해주세요.
- [x] label
- [x] issue number
- [x] conflict resolve

## 💡 Comment
> 전달하고 싶은 내용이 있나요?
- 