### PR TITLE
[FEAT] 일반 사용자의 챌린지 나가기 기능 구현

### DIFF
--- a/src/main/java/com/nookbook/domain/challenge/application/ChallengeService.java
+++ b/src/main/java/com/nookbook/domain/challenge/application/ChallengeService.java
@@ -436,6 +436,7 @@ public class ChallengeService {
             return ChallengeInvitationRes.builder()
                     .userId(friendUserId)
                     .nickname(userService.findById(friendUserId).getNickname())  // userId로 닉네임 조회
+                    .profileImage(userService.findById(friendUserId).getImageUrl())  // userId로 이미지 조회
                     .isInvitable(invitations.stream()
                             .noneMatch(invitation -> invitation.getUser().getUserId().equals(friendUserId)))
                     .build();

--- a/src/main/java/com/nookbook/domain/challenge/application/ParticipantService.java
+++ b/src/main/java/com/nookbook/domain/challenge/application/ParticipantService.java
@@ -6,17 +6,21 @@ import com.nookbook.domain.challenge.domain.ParticipantStatus;
 import com.nookbook.domain.challenge.domain.repository.ParticipantRepository;
 import com.nookbook.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ParticipantService {
     private final ParticipantRepository participantRepository;
 
+
+    @Transactional
     public void saveParticipant(User user, Challenge challenge) {
 
         // 챌린지를 생성한 유저는 participant로 등록
@@ -29,11 +33,15 @@ public class ParticipantService {
         participantRepository.save(participant);
     }
 
-    public String getParticipantRole(Challenge challenge, Participant participant) {
-        if (challenge.getOwner().equals(participant.getUser())) {
-            return "방장";
-        } else {
-            return "일반";
-        }
+    public String getParticipantRole(Participant participant, User owner) {
+        User user = participant.getUser();
+        log.info("Challenge Owner: " + owner.getUserId());
+        log.info("Participant User: " + user.getUserId());
+
+        return owner.getUserId().equals(participant.getUser().getUserId()) ? "방장" : "일반";
+    }
+
+    public Participant getParticipant(Long newOwnerId) {
+        return participantRepository.findByParticipantId(newOwnerId);
     }
 }

--- a/src/main/java/com/nookbook/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/nookbook/domain/challenge/domain/Challenge.java
@@ -83,7 +83,7 @@ public class Challenge extends BaseEntity {
         this.endTime = endTime;
     }
 
-    public void changeOwner(User newOwner) {
-        this.owner = newOwner;
+    public void changeOwner(Participant newOwner) {
+        this.owner = newOwner.getUser();
     }
 }

--- a/src/main/java/com/nookbook/domain/challenge/domain/repository/ParticipantRepository.java
+++ b/src/main/java/com/nookbook/domain/challenge/domain/repository/ParticipantRepository.java
@@ -2,11 +2,13 @@ package com.nookbook.domain.challenge.domain.repository;
 
 import com.nookbook.domain.challenge.domain.Challenge;
 import com.nookbook.domain.challenge.domain.Participant;
+import com.nookbook.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
@@ -17,4 +19,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 
     boolean existsByUserUserIdAndChallenge(Long friendId, Challenge challenge);
 
+    Participant findByUserAndChallenge(User user, Challenge challenge);
+
+    Participant findByParticipantId(Long newOwnerId);
 }

--- a/src/main/java/com/nookbook/domain/challenge/dto/response/ChallengeInvitationRes.java
+++ b/src/main/java/com/nookbook/domain/challenge/dto/response/ChallengeInvitationRes.java
@@ -17,6 +17,9 @@ public class ChallengeInvitationRes {
     @Schema(type = "String", example = "야옹아멍멍해바", description = "친구의 닉네임")
     private String nickname;
 
+    @Schema(type = "String", example = "야옹아멍멍해바.jpg", description = "친구의 프로필 이미지")
+    private String profileImage;
+
     @Schema(type = "boolean", example = "true", description = "초대 가능 여부")
     private boolean isInvitable;
 }

--- a/src/main/java/com/nookbook/domain/challenge/exception/ChallengeOwnerCantLeaveException.java
+++ b/src/main/java/com/nookbook/domain/challenge/exception/ChallengeOwnerCantLeaveException.java
@@ -1,0 +1,9 @@
+package com.nookbook.domain.challenge.exception;
+
+import com.nookbook.global.exception.AuthorizedException;
+
+public class ChallengeOwnerCantLeaveException extends AuthorizedException {
+    public ChallengeOwnerCantLeaveException() {
+        super("C003", "방장은 챌린지에서 나갈 수 없습니다.");
+    }
+}

--- a/src/main/java/com/nookbook/domain/challenge/presentation/ChallengeController.java
+++ b/src/main/java/com/nookbook/domain/challenge/presentation/ChallengeController.java
@@ -218,4 +218,20 @@ public class ChallengeController {
     ) {
         return challengeService.rejectInvitation(userPrincipal, challengeId);
     }
+
+    // 챌린지 나가기 API
+    @Operation(summary = "챌린지 나가기 API", description = "참여 중인 챌린지에서 나가는 API입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "챌린지 나가기 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}),
+            @ApiResponse(responseCode = "400", description = "챌린지 나가기 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @DeleteMapping("/exit/{challengeId}")
+    public ResponseEntity<?> leaveChallenge(
+            @Parameter @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "챌린지 ID") @PathVariable Long challengeId
+    ) {
+        return challengeService.leaveChallenge(userPrincipal, challengeId);
+    }
+
+
 }


### PR DESCRIPTION
## 👑 Summary
> 어떤 내용의 PR인가요?
- 챌린지 나가기 기능

## 🫧 To be noted
> PR을 검토할 때 확인해야 할 사항이 있나요?
- 방장이 방장 넘기기를 하지 않고 나가기를 했을 시의 예외 처리가 되었는가?

## 💫 issue number
> 이슈 번호를 작성해주새요
- #105 

## ☑️ Checklist
> PR 요청 시 체크해주세요.
- [x] label
- [x] issue number
- [x] conflict resolve

## 💡 Comment
> 전달하고 싶은 내용이 있나요?
- 현재 챌린지 방장 여부를 조회하는 부분에서 User 정보가 아닌 Participant 정보로 조회되고 있어 불일치 문제가 발생하여 해결했습니다.
- 타 API들을 포함하여 파라미터는 모두 Participant 정보를 받지만, Owner 객체는 User이므로 이 점 유의하여 서비스 로직 점검하였습니다.