### PR TITLE
[FIX] 독서 기록 종료 시간 조회 오류

### DIFF
--- a/src/main/java/com/nookbook/domain/auth/application/CustomTokenProviderService.java
+++ b/src/main/java/com/nookbook/domain/auth/application/CustomTokenProviderService.java
@@ -121,7 +121,6 @@ public class CustomTokenProviderService {
             byte[] keyBytes = Decoders.BASE64.decode(base64SecretKey);
             Key key = Keys.hmacShaKeyFor(keyBytes);
 
-            log.info("Key: {}", key);
 
             Jwts.parserBuilder()
                     .setSigningKey(key)

--- a/src/main/java/com/nookbook/domain/user_book/application/UserBookService.java
+++ b/src/main/java/com/nookbook/domain/user_book/application/UserBookService.java
@@ -183,7 +183,7 @@ public class UserBookService {
         }
         else{
             // HH:SS 형식으로 변환
-            return timerList.get(timerList.size() - 1).getCreatedAt().toLocalTime().toString();
+            return timerList.get(timerList.size() - 1).getUpdatedAt().toLocalTime().toString();
         }
     }
 


### PR DESCRIPTION
## 👑 Summary
> 어떤 내용의 PR인가요?
- 독서 캘린더를 통해 기록 정보를 조회할 때, 종료 시간이 시작 시간과 동일하게 출력되는 오류
- endTime 조회 시 생성일이 아닌 수정일 시간으로 수정

## 🫧 To be noted
> PR을 검토할 때 확인해야 할 사항이 있나요?
-

## 💫 issue number
> 이슈 번호를 작성해주새요
- #124 

## ☑️ Checklist
> PR 요청 시 체크해주세요.
- [x] label
- [x] issue number
- [x] conflict resolve

## 💡 Comment
> 전달하고 싶은 내용이 있나요?
- 