### PR TITLE
[REFACTOR] 마이페이지, 친구페이지 컨트롤러 및 API 분리 

### DIFF
--- a/src/main/java/com/nookbook/domain/note/application/NoteService.java
+++ b/src/main/java/com/nookbook/domain/note/application/NoteService.java
@@ -83,7 +83,8 @@ public class NoteService {
         DefaultAssert.isTrue(note.getUserBook().getUser() == user, "유효한 접근이 아닙니다.");
         if (updateNoteReq.getTitle() != null || updateNoteReq.getContent() != null) {
             note.updateNote(updateNoteReq.getTitle(), updateNoteReq.getContent());
-        } else if (updateNoteReq.getLocked() != null) {
+        }
+        if (updateNoteReq.getLocked() != null) {
             note.updateLocked(updateNoteReq.getLocked());
         }
         ApiResponse apiResponse = ApiResponse.builder()

--- a/src/main/java/com/nookbook/domain/user/application/UserService.java
+++ b/src/main/java/com/nookbook/domain/user/application/UserService.java
@@ -140,11 +140,12 @@ public class UserService {
     }
 
     public ResponseEntity<ApiResponse> getUserInfo(UserPrincipal userPrincipal, Long userId) {
+        boolean isSame = userId == userPrincipal.getId();
         User user = validUserByUserId(userPrincipal.getId());
-        User targetUser = validUserByUserId(userId);
+        User targetUser = isSame ? user : validUserByUserId(userId);
 
         int num = friendRepository.countBySenderOrReceiverAndFriendRequestStatus(targetUser, FriendRequestStatus.FRIEND_ACCEPT);
-        String friendRequestStatus = user != targetUser ? determineFriendStatus(user, targetUser) : null;
+        String friendRequestStatus = isSame ? null : determineFriendStatus(user, targetUser);
         UserInfoRes userInfoRes = UserInfoRes.builder()
                 .nicknameId(targetUser.getNicknameId())
                 .nickname(targetUser.getNickname())
@@ -166,7 +167,7 @@ public class UserService {
             if (friend.getFriendRequestStatus() == FriendRequestStatus.FRIEND_REQUEST) {
                 return user.equals(friend.getSender()) ? "REQUEST_SENT" : "REQUEST_RECEIVED";
             } else {
-                return friend.getStatus().toString();
+                return friend.getFriendRequestStatus().toString();
             }
         }).orElse("NONE");
     }

--- a/src/main/java/com/nookbook/domain/user/presentation/FriendController.java
+++ b/src/main/java/com/nookbook/domain/user/presentation/FriendController.java
@@ -1,0 +1,193 @@
+package com.nookbook.domain.user.presentation;
+
+import com.nookbook.domain.book.applicaiton.BookService;
+import com.nookbook.domain.book.dto.response.MostReadCategoriesRes;
+import com.nookbook.domain.note.application.NoteService;
+import com.nookbook.domain.note.dto.response.OtherUserNoteListRes;
+import com.nookbook.domain.user.application.FriendService;
+import com.nookbook.domain.user.application.UserService;
+import com.nookbook.domain.user.dto.response.FriendsRequestRes;
+import com.nookbook.domain.user.dto.response.SearchUserRes;
+import com.nookbook.domain.user.dto.response.UserInfoRes;
+import com.nookbook.global.config.security.token.CurrentUser;
+import com.nookbook.global.config.security.token.UserPrincipal;
+import com.nookbook.global.payload.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.InvalidParameterException;
+import java.util.Objects;
+import java.util.Optional;
+
+@Tag(name = "Friend", description = "Friend API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class FriendController {
+
+    private final UserService userService;
+    private final BookService bookService;
+    private final FriendService friendService;
+    private final NoteService noteService;
+
+    @Operation(summary = "친구 추가 - 검색", description = "사용자 전체를 대상으로 단어를 검색하여 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = SearchUserRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping("/friend/all")
+    public ResponseEntity<?> searchAllUsers(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "검색하고자 하는 단어를 입력해주세요.") @RequestParam String keyword,
+            @Parameter(description = "페이지의 숫자입니다. 페이지는 0부터 시작합니다.") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 내 요소의 개수입니다.") @RequestParam(defaultValue = "20") int size
+    ) {
+        return friendService.searchUsers(userPrincipal, keyword, page, size);
+    }
+
+    @Operation(summary = "친구 목록 - 조회", description = "친구 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = SearchUserRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping("/friend")
+    public ResponseEntity<?> getFriends(
+            @CurrentUser UserPrincipal userPrincipal
+    ) {
+        return friendService.getFriends(userPrincipal, null);
+    }
+
+    @Operation(summary = "친구 추가 - 내가 보낸/받은 요청 목록 조회", description = "내가 보낸/받은 요청 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = FriendsRequestRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping("/friend/pending")
+    public ResponseEntity<?> getFriendsRequest(
+            @CurrentUser UserPrincipal userPrincipal
+    ) {
+        return friendService.getFriendRequestList(userPrincipal);
+    }
+
+    @Operation(summary = "친구 요청", description = "다른 사용자에게 친구를 요청합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @PostMapping("/friend/pending/{userId}")
+    public ResponseEntity<?> sendFriendRequest(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.", required = true) @PathVariable Long userId
+    ) {
+        return friendService.sendFriendRequest(userPrincipal, userId);
+    }
+
+    @Operation(summary = "친구 수락/거절", description = "요청을 수락하거나 거절합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @PutMapping("/friend/pending/{friendId}")
+    public ResponseEntity<?> acceptOrRejectFriendRequest(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "친구 요청 목록에서 조회한 friendId를 입력해주세요.", required = true) @PathVariable Long friendId,
+            @Parameter(description = "요청의 수락 여부입니다. true: 수락, false: 거절", required = true) @RequestParam boolean isAccept
+    ) {
+        return friendService.updateFriendRequestStatus(userPrincipal, friendId, isAccept);
+    }
+
+    @Operation(summary = "친구 요청 취소", description = "내가 보낸 친구 요청을 취소합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "취소 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "취소 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @DeleteMapping ("/friend/pending/{friendId}")
+    public ResponseEntity<?> cancelFriendRequest(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "친구 요청 목록에서 조회한 friendId를 입력해주세요.", required = true) @PathVariable Long friendId
+    ) {
+        return friendService.deleteFriendRequest(userPrincipal, friendId, false);
+    }
+
+    @Operation(summary = "친구 삭제", description = "친구를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "삭제 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "삭제 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @DeleteMapping ("/friend/{friendId}")
+    public ResponseEntity<?> deleteFriendRequest(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "친구 목록에서 조회한 friendId를 입력해주세요.", required = true) @PathVariable Long friendId
+    ) {
+        return friendService.deleteFriendRequest(userPrincipal, friendId, true);
+    }
+
+    // 친구페이지
+    @Operation(summary = "독서 통계 조회", description = "친구페이지의 독서 통계(카테고리, 연도 및 월별 선택)를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = MostReadCategoriesRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping("/user/{userId}/report")
+    public ResponseEntity<?> findReadingReport(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "독서 통계를 조회하고자 하는 사용자의 id를 입력해주세요.", required = true) @PathVariable Long userId,
+            @Parameter(description = "독서 통계의 종류입니다. category: 카테고리별(기본) , year: 연도별", required = true) @RequestParam(defaultValue = "category") String type,
+            @Parameter(description = "type이 year인 경우, 독서 통계를 확인하려는 연도를 입력해주세요") @RequestParam(required = false) Optional<Integer> targetYear
+    ) {
+        if (Objects.equals(type, "category")) {
+            return bookService.countReadBooksByCategory(userPrincipal, userId);
+        } else if (Objects.equals(type, "year") && targetYear.isPresent()) {
+            return bookService.countReadBooksByYear(userPrincipal, userId, targetYear);
+        } else throw new InvalidParameterException("유효한 파라미터가 아닙니다.");
+    }
+
+    @Operation(summary = "사용자 정보 조회", description = "친구페이지의 정보(아이디, 닉네임, 프로필 이미지, 친구 수, 친구 요청 상태)를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = UserInfoRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<?> findUserInformation(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.", required = true) @PathVariable Long userId
+    ) {
+        return userService.getUserInfo(userPrincipal, userId);
+    }
+
+    @Operation(summary = "기록 전체보기 목록 조회 및 검색", description = "친구페이지의 기록 전체보기 목록 조회 또는 검색하여 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = OtherUserNoteListRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping("/user/{userId}/note")
+    public ResponseEntity<?> findUserAllNotes(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.", required = true) @PathVariable Long userId,
+            @Parameter(description = "검색하고자 하는 단어를 입력해주세요. 없다면 입력하지 않습니다.") @RequestParam(required = false) String keyword
+    ) {
+        return noteService.getUserPageNoteList(userPrincipal, userId, keyword);
+    }
+
+    @Operation(summary = "기록 전체보기 상세 조회", description = "친구페이지의 기록 전체보기에서 도서를 선택하여 상세 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = OtherUserNoteListRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping("/user/{userId}/note/book/{bookId}")
+    public ResponseEntity<?> findUserAllNotesDetail(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.", required = true) @PathVariable Long userId,
+            @Parameter(description = "조회하고자 하는 노트의 **도서 id**를 입력해주세요.", required = true) @PathVariable Long bookId
+    ) {
+        return noteService.getUserPageNoteListByBookId(userPrincipal, userId, bookId);
+    }
+}

--- a/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
+++ b/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
@@ -1,16 +1,12 @@
 package com.nookbook.domain.user.presentation;
 
 import com.nookbook.domain.book.applicaiton.BookService;
-import com.nookbook.domain.book.dto.response.BookStatisticsRes;
 import com.nookbook.domain.book.dto.response.MostReadCategoriesRes;
 import com.nookbook.domain.note.application.NoteService;
 import com.nookbook.domain.note.dto.response.OtherUserNoteListRes;
-import com.nookbook.domain.user.application.FriendService;
 import com.nookbook.domain.user.application.UserService;
 import com.nookbook.domain.user.dto.request.NicknameCheckReq;
 import com.nookbook.domain.user.dto.request.NicknameIdCheckReq;
-import com.nookbook.domain.user.dto.response.FriendsRequestRes;
-import com.nookbook.domain.user.dto.response.SearchUserRes;
 import com.nookbook.domain.user.dto.response.UserInfoRes;
 import com.nookbook.global.config.security.token.CurrentUser;
 import com.nookbook.global.config.security.token.UserPrincipal;
@@ -29,6 +25,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.security.InvalidParameterException;
+import java.util.Objects;
 import java.util.Optional;
 
 @Tag(name = "User MyPage", description = "User MyPage API")
@@ -40,9 +38,8 @@ public class MyPageController {
     private final UserService userService;
     private final BookService bookService;
     private final NoteService noteService;
-    private final FriendService friendService;
 
-    @Operation(summary = "[마이페이지] 사용자 아이디 변경", description = "사용자의 아이디를 변경합니다.")
+    @Operation(summary = "사용자 아이디 변경", description = "사용자의 아이디를 변경합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "변경 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
             @ApiResponse(responseCode = "400", description = "변경 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
@@ -55,7 +52,7 @@ public class MyPageController {
         return userService.updateNicknameId(userPrincipal, nicknameIdCheckReq);
     }
 
-    @Operation(summary = "[마이페이지] 사용자 닉네임 변경", description = "사용자의 닉네임을 변경합니다.")
+    @Operation(summary = "사용자 닉네임 변경", description = "사용자의 닉네임을 변경합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "변경 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
             @ApiResponse(responseCode = "400", description = "변경 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
@@ -68,7 +65,7 @@ public class MyPageController {
         return userService.updateNickname(userPrincipal, nicknameCheckReq);
     }
 
-    @Operation(summary = "[마이페이지] 사용자 프로필 이미지 변경", description = "사용자의 프로필 이미지를 변경합니다.")
+    @Operation(summary = "사용자 프로필 이미지 변경", description = "사용자의 프로필 이미지를 변경합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "변경 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
             @ApiResponse(responseCode = "400", description = "변경 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
@@ -82,164 +79,60 @@ public class MyPageController {
         return userService.updateImage(userPrincipal, isDefaultImage, image);
     }
 
-    @Operation(summary = "[마이페이지] 독서 통계(카테고리별)", description = "마이페이지 또는 친구페이지의 독서 통계(카테고리)를 조회합니다.")
+    @Operation(summary = "독서 통계", description = "마이페이지의 독서 통계(카테고리, 연도 및 월별)를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = MostReadCategoriesRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @GetMapping("/{userId}/report/category")
-    public ResponseEntity<?> findReadingReportByCategory(
+    @GetMapping("/report")
+    public ResponseEntity<?> findMyReadingReport(
             @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "독서 통계(카테고리별)을 조회하고자 하는 사용자의 id를 입력해주세요. 내 통계인 경우에도 userId를 전달합니다.") @PathVariable Long userId
+            @Parameter(description = "독서 통계의 종류입니다. category: 카테고리별(기본) , year: 연도별", required = true) @RequestParam(defaultValue = "category") String type,
+            @Parameter(description = "type이 year인 경우, 독서 통계를 확인하려는 연도를 입력해주세요") @RequestParam(required = false) Optional<Integer> targetYear
     ) {
-        return bookService.countReadBooksByCategory(userPrincipal, userId);
+        if (Objects.equals(type, "category")) {
+            return bookService.countReadBooksByCategory(userPrincipal, userPrincipal.getId());
+        } else if (Objects.equals(type, "year") && targetYear.isPresent()) {
+            return bookService.countReadBooksByYear(userPrincipal, userPrincipal.getId(), targetYear);
+        } else throw new InvalidParameterException("유효한 파라미터가 아닙니다.");
     }
 
-    @Operation(summary = "[마이페이지] 독서 통계(연도 및 월별)", description = "마이페이지 또는 친구페이지의 독서 통계(연도 및 월별)를 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = BookStatisticsRes.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    })
-    @GetMapping("/{userId}/report")
-    public ResponseEntity<?> findReadingReportByYear(
-            @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "독서 통계(연도 및 월별)을 조회하고자 하는 사용자의 id를 입력해주세요. 내 통계인 경우에도 userId를 전달합니다.") @PathVariable Long userId,
-            @Parameter(description = "독서 통계를 확인하려는 연도를 입력해주세요", required = true) @RequestParam int year
-    ) {
-        return bookService.countReadBooksByYear(userPrincipal, userId, year);
-    }
-
-    @Operation(summary = "[마이페이지] 정보 조회", description = "마이페이지 또는 친구페이지의 정보(아이디, 닉네임, 프로필 이미지, 친구 수)를 조회합니다. 친구의 페이지인 경우 친구 상태를 추가하여 반환합니다.")
+    @Operation(summary = "내 정보 조회", description = "마이페이지의 정보(아이디, 닉네임, 프로필 이미지, 친구 수)를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = UserInfoRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @GetMapping("/{userId}")
-    public ResponseEntity<?> findUserInformation(
-            @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요. 나의 프로필인 경우에도 userId를 전달합니다.") @PathVariable Long userId
+    @GetMapping("")
+    public ResponseEntity<?> findMyInformation(
+            @CurrentUser UserPrincipal userPrincipal
     ) {
-        return userService.getUserInfo(userPrincipal, userId);
+        return userService.getUserInfo(userPrincipal, userPrincipal.getId());
     }
 
-    @Operation(summary = "[마이페이지] 기록 전체보기 목록 조회 및 검색", description = "마이페이지 또는 친구페이지의 기록 전체보기 목록 조회 또는 검색하여 조회합니다.")
+    @Operation(summary = "기록 전체보기 목록 조회 및 검색", description = "마이페이지의 기록 전체보기 목록 조회 또는 검색하여 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = OtherUserNoteListRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @GetMapping("/{userId}/note")
-    public ResponseEntity<?> findUserAllNotes(
+    @GetMapping("/note")
+    public ResponseEntity<?> findMyAllNotes(
             @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요. 나의 프로필인 경우에도 userId를 전달합니다.") @PathVariable Long userId,
             @Parameter(description = "검색하고자 하는 단어를 입력해주세요. 없다면 입력하지 않습니다.") @RequestParam(required = false) String keyword
     ) {
-        return noteService.getMyPageNoteList(userPrincipal, userId, keyword);
+        return noteService.getUserPageNoteList(userPrincipal, userPrincipal.getId(), keyword);
     }
 
-    @Operation(summary = "[마이페이지] 기록 전체보기 상세 조회", description = "마이페이지 또는 친구페이지의 기록 전체보기에서 도서를 선택하여 상세 조회합니다.")
+    @Operation(summary = "기록 전체보기 상세 조회", description = "마이페이지의 기록 전체보기에서 도서를 선택하여 상세 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = OtherUserNoteListRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @GetMapping("/{userId}/note/{bookId}")
-    public ResponseEntity<?> findUserAllNotesDetail(
+    @GetMapping("/note/book/{bookId}")
+    public ResponseEntity<?> findMyAllNotesDetail(
             @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.") @PathVariable Long userId,
-            @Parameter(description = "조회하고자 하는 노트의 **도서 id**를 입력해주세요.") @PathVariable Long bookId
+            @Parameter(description = "조회하고자 하는 노트의 **도서 id**를 입력해주세요.", required = true) @PathVariable Long bookId
     ) {
-        return noteService.getMyPageNoteListByBookId(userPrincipal, userId, bookId);
-    }
-
-    @Operation(summary = "친구 추가 - 검색", description = "사용자 전체를 대상으로 단어를 검색하여 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = SearchUserRes.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    })
-    @GetMapping("/friend/all")
-    public ResponseEntity<?> searchAllUsers(
-            @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "검색하고자 하는 단어를 입력해주세요.") @RequestParam String keyword,
-            @Parameter(description = "페이지의 숫자입니다. 페이지는 0부터 시작합니다.") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "페이지 내 요소의 개수입니다.") @RequestParam(defaultValue = "20") int size
-    ) {
-        return friendService.searchUsers(userPrincipal, keyword, page, size);
-    }
-
-    @Operation(summary = "친구 목록 - 조회", description = "친구 목록을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = SearchUserRes.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    })
-    @GetMapping("/friend")
-    public ResponseEntity<?> getFriends(
-            @CurrentUser UserPrincipal userPrincipal
-    ) {
-        return friendService.getFriends(userPrincipal, null);
-    }
-
-    @Operation(summary = "친구 추가 - 내가 보낸/받은 요청 목록 조회", description = "내가 보낸/받은 요청 목록을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = FriendsRequestRes.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    })
-    @GetMapping("/friend/pending")
-    public ResponseEntity<?> getFriendsRequest(
-            @CurrentUser UserPrincipal userPrincipal
-    ) {
-        return friendService.getFriendRequestList(userPrincipal);
-    }
-
-    @Operation(summary = "친구 요청", description = "다른 사용자에게 친구를 요청합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    })
-    @PostMapping("/friend/pending/{userId}")
-    public ResponseEntity<?> sendFriendRequest(
-            @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.") @PathVariable Long userId
-    ) {
-        return friendService.sendFriendRequest(userPrincipal, userId);
-    }
-
-    @Operation(summary = "친구 수락/거절", description = "요청을 수락하거나 거절합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    })
-    @PutMapping("/friend/pending/{friendId}")
-    public ResponseEntity<?> acceptOrRejectFriendRequest(
-            @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "친구 요청 목록에서 조회한 friendId를 입력해주세요.") @PathVariable Long friendId,
-            @Parameter(description = "요청의 수락 여부입니다. true: 수락, false: 거절") @RequestParam boolean isAccept
-    ) {
-        return friendService.updateFriendRequestStatus(userPrincipal, friendId, isAccept);
-    }
-
-    @Operation(summary = "친구 요청 취소", description = "내가 보낸 친구 요청을 취소합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "취소 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "취소 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    })
-    @DeleteMapping ("/friend/pending/{friendId}")
-    public ResponseEntity<?> cancelFriendRequest(
-            @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "친구 요청 목록에서 조회한 friendId를 입력해주세요.") @PathVariable Long friendId
-    ) {
-        return friendService.deleteFriendRequest(userPrincipal, friendId, false);
-    }
-
-    @Operation(summary = "친구 삭제", description = "친구를 삭제합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "삭제 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "삭제 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    })
-    @DeleteMapping ("/friend/{friendId}")
-    public ResponseEntity<?> deleteFriendRequest(
-            @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "친구 목록에서 조회한 friendId를 입력해주세요.") @PathVariable Long friendId
-    ) {
-        return friendService.deleteFriendRequest(userPrincipal, friendId, true);
+        return noteService.getUserPageNoteListByBookId(userPrincipal, userPrincipal.getId(), bookId);
     }
 
 }


### PR DESCRIPTION
## 👑 Summary
> 어떤 내용의 PR인가요?
- 친구페이지 컨트롤러를 생성하여 마이페이지와 분리하고, 공통으로 사용하는 API를 분리했습니다. 

## 🫧 To be noted
> PR을 검토할 때 확인해야 할 사항이 있나요?
- 추가로 타인의 프로필 조회 API에서 응답 값 중 `requestStatus` 가 잘못 표기된 것을 수정했습니다.
- 독서 통계 조회 API에서 카테고리별과 연도별 API를 통합했습니다.

## 💫 issue number
> 이슈 번호를 작성해주새요
- resolve #162 
- resolve #163 

## ☑️ Checklist
> PR 요청 시 체크해주세요.
- [x] label
- [x] issue number
- [x] conflict resolve

## 💡 Comment
> 전달하고 싶은 내용이 있나요?
- 관련 URL이 대대적으로 변경되었습니다. 아래의 상세한 변경사항을 참고 부탁드립니다.

------
## 1. 오류 수정
- 노트 수정 API:  `locked` 업데이트 안되는 오류 수정
- 타인의 프로필 조회 API: 응답 값 중 `requestStatus` 값 오류 수정
## 2. 마이페이지, 친구페이지 API 및 컨트롤러 분리
- URL 구조 변경 및  요청 시 필요 파라미터 변경
- 마이페이지 요청 파라미터에서 `userId` 삭제
### 2-1. 친구 관련 API URL 전체 수정
기존: /api/v1/my-page/friend 
수정: /api/v1/friend로 변경
 ### 2-2. 친구페이지 API URL 수정
기존: /api/v1/my-page/{userId}
수정: /api/v1/user/{userId}
## 3. 독서 통계 조회
카테고리, 년도별 통계 조회 API 통합
/report와 /report/category로 구분하지 않고 request parameter로 `type`을 사용하여 구분
## 4. 기록 전체보기 URL 수정(마이페이지, 친구페이지 동일)
기존: /my-page/**/note/{bookId}**
수정:  /my-page OR /user/{userId}**/note/book/{bookId}**