### PR TITLE
[REFACTOR] 도서, 타이머, 노트, 마이페이지, 친구 URL 변경

### DIFF
--- a/src/main/java/com/nookbook/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nookbook/domain/book/presentation/BookController.java
@@ -2,18 +2,12 @@ package com.nookbook.domain.book.presentation;
 
 import com.nookbook.domain.book.applicaiton.BookService;
 import com.nookbook.domain.book.dto.response.*;
-import com.nookbook.domain.keyword.application.KeywordService;
-import com.nookbook.domain.timer.application.TimerService;
-import com.nookbook.domain.timer.dto.request.CreateTimerReq;
-import com.nookbook.domain.timer.dto.response.TimerRes;
 import com.nookbook.domain.user_book.domain.BookStatus;
 import com.nookbook.global.config.security.token.CurrentUser;
 import com.nookbook.global.config.security.token.UserPrincipal;
 import com.nookbook.global.payload.ErrorResponse;
-import com.nookbook.global.payload.Message;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -23,17 +17,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalTime;
-
 @Tag(name = "Book", description = "Book API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/book")
+@RequestMapping("/api/v1/books")
 public class BookController {
 
     private final BookService bookService;
-    private final KeywordService keywordService;
-    private final TimerService timerService;
 
     @Operation(summary = "도서 검색", description = "도서를 제목, 저자, 출판사로 검색합니다.")
     @ApiResponses(value = {
@@ -54,7 +44,7 @@ public class BookController {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = BookRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     } )
-    @GetMapping
+    @GetMapping("")
     public ResponseEntity<?> findBookDetail(
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "조회하려는 도서의 isbn을 입력해주세요.", required = true) @RequestParam String isbn
@@ -67,7 +57,7 @@ public class BookController {
             @ApiResponse(responseCode = "200", description = "변경 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = BookStatus.class) ) } ),
             @ApiResponse(responseCode = "400", description = "변경 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     } )
-    @PatchMapping("/{bookId}")
+    @PatchMapping("/{bookId}/status")
     public ResponseEntity<?> updateBookStatus(
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "상태를 변경하려는 도서의 id를 입력해주세요.", required = true) @PathVariable Long bookId
@@ -80,7 +70,7 @@ public class BookController {
             @ApiResponse(responseCode = "200", description = "검색 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = BestSellerRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "검색 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     } )
-    @GetMapping("/best-seller")
+    @GetMapping("/best-sellers")
     public ResponseEntity<?> findBestSellers(
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "베스트셀러의 카테고리를 입력해주세요. 종합(0), 소설(1), 경제/경영(170), 자기계발(336), 시(50940), 에세이(55889), 인문/교양(656), 취미/실용(55890), 매거진(2913), 기본값은 종합(0)입니다.", required = true) @RequestParam(defaultValue = "0") int category,
@@ -88,73 +78,5 @@ public class BookController {
             @Parameter(description = "베스트셀러를 페이지별로 조회합니다. **Page는 1부터 시작합니다!**", required = true) @RequestParam(defaultValue = "1") int page
     ) {
         return bookService.getBestSellerByCategory(page, category, size);
-    }
-
-
-    // 검색어 관련
-    @Operation(summary = "검색어 조회", description = "사용자의 검색어를 최대 5개 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = KeywordRes.class))) } ),
-            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    } )
-    @GetMapping("/keyword")
-    public ResponseEntity<?> findKeywords(
-            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal
-    ) {
-        return keywordService.getKeywords(userPrincipal);
-    }
-
-    @Operation(summary = "검색어 삭제", description = "사용자의 검색어를 삭제합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "검색 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class)) } ),
-            @ApiResponse(responseCode = "400", description = "검색 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    } )
-    @DeleteMapping("/keyword/{keywordId}")
-    public ResponseEntity<?> deleteKeyword(
-            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "검색어의 id를 입력해주세요.", required = true) @PathVariable Long keywordId
-    ) {
-        return keywordService.deleteKeyword(userPrincipal, keywordId);
-    }
-
-    @Operation(summary = "타이머 기록 조회", description = "타이머 기록의 누적 시간 및 목록을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = TimerRes.class)) } ),
-            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    } )
-    @GetMapping("/{bookId}/timer")
-    public ResponseEntity<?> getTimerRecord(
-            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "도서의 id를 입력해주세요.", required = true) @PathVariable Long bookId
-    ) {
-        return timerService.getTimerRecords(userPrincipal, bookId);
-    }
-
-    @Operation(summary = "타이머 종료", description = "타이머를 종료하고, 타이머 기록을 저장합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = TimerRes.class)) } ),
-            @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    } )
-    @PostMapping("/{bookId}/timer/{timerId}")
-    public ResponseEntity<?> saveTimerRecord(
-            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "도서의 id를 입력해주세요.", required = true) @PathVariable Long bookId,
-            @Parameter(description = "타이머의 id를 입력해주세요.", required = true) @PathVariable Long timerId,
-            @Parameter(description = "시간을 입력해주세요.", required = true) @RequestBody CreateTimerReq createTimerReq
-            ) {
-        return timerService.saveTimerRecord(userPrincipal, bookId, timerId, createTimerReq);
-    }
-
-    @Operation(summary = "타이머 시작", description = "타이머를 시작합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class)) } ),
-            @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    } )
-    @PostMapping("/{bookId}/timer")
-    public ResponseEntity<?> startTimerRecord(
-            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "도서의 id를 입력해주세요.", required = true) @PathVariable Long bookId
-    ) {
-        return timerService.updateTimerStatus(userPrincipal, bookId);
     }
 }

--- a/src/main/java/com/nookbook/domain/keyword/presentation/KeywordController.java
+++ b/src/main/java/com/nookbook/domain/keyword/presentation/KeywordController.java
@@ -1,0 +1,53 @@
+package com.nookbook.domain.keyword.presentation;
+
+import com.nookbook.domain.book.dto.response.KeywordRes;
+import com.nookbook.domain.keyword.application.KeywordService;
+import com.nookbook.global.config.security.token.CurrentUser;
+import com.nookbook.global.config.security.token.UserPrincipal;
+import com.nookbook.global.payload.ErrorResponse;
+import com.nookbook.global.payload.Message;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Keyword", description = "검색어 관련 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/keywords")
+public class KeywordController {
+
+    private final KeywordService keywordService;
+
+    @Operation(summary = "검색어 조회", description = "사용자의 검색어를 최대 5개 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = KeywordRes.class))) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    } )
+    @GetMapping("")
+    public ResponseEntity<?> findKeywords(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal
+    ) {
+        return keywordService.getKeywords(userPrincipal);
+    }
+
+    @Operation(summary = "검색어 삭제", description = "사용자의 검색어를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "검색 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class)) } ),
+            @ApiResponse(responseCode = "400", description = "검색 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    } )
+    @DeleteMapping("/{keywordId}")
+    public ResponseEntity<?> deleteKeyword(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "검색어의 id를 입력해주세요.", required = true) @PathVariable Long keywordId
+    ) {
+        return keywordService.deleteKeyword(userPrincipal, keywordId);
+    }
+}

--- a/src/main/java/com/nookbook/domain/note/application/NoteService.java
+++ b/src/main/java/com/nookbook/domain/note/application/NoteService.java
@@ -42,9 +42,9 @@ public class NoteService {
 
     // 노트 저장
     @Transactional
-    public ResponseEntity<?> saveNewNote(UserPrincipal userPrincipal, CreateNoteReq createNoteReq) {
+    public ResponseEntity<?> saveNewNote(UserPrincipal userPrincipal, Long bookId, CreateNoteReq createNoteReq) {
         User user = validUserById(userPrincipal.getId());
-        Book book = validBookById(createNoteReq.getBookId());
+        Book book = validBookById(bookId);
         UserBook userBook;
         // user_book에 없으면 생성
         Optional<UserBook> userBookOptional = userBookRepository.findByUserAndBook(user, book);
@@ -110,36 +110,6 @@ public class NoteService {
                 .information(Message.builder()
                         .message("기록이 삭제되었습니다.")
                         .build())
-                .build();
-        return ResponseEntity.ok(apiResponse);
-    }
-
-    // 책 정보 조회(제목, 이미지) && 노트 목록 조회
-    public ResponseEntity<?> getNoteListByBookId(UserPrincipal userPrincipal, Long bookId) {
-        User user = validUserById(userPrincipal.getId());
-        Book book = validBookById(bookId);
-
-        Optional<UserBook> userBookOptional = userBookRepository.findByUserAndBook(user, book);
-        DefaultAssert.isTrue(userBookOptional.isPresent(), "기록이 존재하지 않습니다.");
-        UserBook userBook = userBookOptional.get();
-
-        List<Note> notes =  noteRepository.findByUserBookOrderByCreatedAtDesc(userBook);
-        List<NoteListRes> noteListRes = notes.stream()
-                .map(note -> NoteListRes.builder()
-                        .noteId(note.getNoteId())
-                        .title(note.getTitle())
-                        .createdDate(note.getCreatedAt().toLocalDate().toString())
-                        .build())
-                .toList();
-        NoteRes noteRes = NoteRes.builder()
-                .bookTitle(book.getTitle())
-                .bookImage(book.getImage())
-                .noteCount(notes.size())
-                .noteListRes(noteListRes)
-                .build();
-        ApiResponse apiResponse = ApiResponse.builder()
-                .check(true)
-                .information(noteRes)
                 .build();
         return ResponseEntity.ok(apiResponse);
     }

--- a/src/main/java/com/nookbook/domain/note/application/NoteService.java
+++ b/src/main/java/com/nookbook/domain/note/application/NoteService.java
@@ -147,7 +147,7 @@ public class NoteService {
     }
 
     public ResponseEntity<?> deleteImage(String imageUrl) {
-        s3Uploader.deleteFile(s3Uploader.extractImageNameFromUrl(imageUrl));
+        s3Uploader.deleteFile(s3Uploader.extractFileName(imageUrl));
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)
                 .information("이미지가 삭제되었습니다.")

--- a/src/main/java/com/nookbook/domain/note/dto/request/CreateNoteReq.java
+++ b/src/main/java/com/nookbook/domain/note/dto/request/CreateNoteReq.java
@@ -8,9 +8,6 @@ import lombok.NoArgsConstructor;
 @Getter
 public class CreateNoteReq {
 
-    @Schema(type = "Long", example = "1", description = "도서의 id")
-    private Long bookId;
-
     @Schema(type = "String", example = "몰입이란 몰까...", description = "독서 기록의 제목")
     private String title;
 

--- a/src/main/java/com/nookbook/domain/note/presentation/NoteController.java
+++ b/src/main/java/com/nookbook/domain/note/presentation/NoteController.java
@@ -102,7 +102,7 @@ public class NoteController {
             @ApiResponse(responseCode = "200", description = "업로드 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ImageUrlRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "업로드 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     } )
-    @PostMapping("/notes/images")
+    @PostMapping("/notes/image")
     public ResponseEntity<?> uploadNoteImage(
             @Parameter(description = "업로드할 이미지를 입력해주세요.", required = true) @RequestPart MultipartFile image
     ) {
@@ -114,7 +114,7 @@ public class NoteController {
             @ApiResponse(responseCode = "200", description = "삭제 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
             @ApiResponse(responseCode = "400", description = "삭제 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     } )
-    @DeleteMapping("/notes/images")
+    @DeleteMapping("/notes/image")
     public ResponseEntity<?> deleteNoteImage(
             @Parameter(description = "삭제할 이미지의 URL을 입력해주세요.", required = true) @RequestParam String imageUrl
     ) {

--- a/src/main/java/com/nookbook/domain/timer/dto/request/UpdateTimerReq.java
+++ b/src/main/java/com/nookbook/domain/timer/dto/request/UpdateTimerReq.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import java.math.BigInteger;
 
 @Getter
-public class CreateTimerReq {
+public class UpdateTimerReq {
 
     @Schema(type = "BigInteger", example = "48000", description = "특정 도서의 타이머 독서 시간입니다. 초단위로 전달해주세요.")
     private BigInteger time;

--- a/src/main/java/com/nookbook/domain/timer/presentation/TimerController.java
+++ b/src/main/java/com/nookbook/domain/timer/presentation/TimerController.java
@@ -1,0 +1,67 @@
+package com.nookbook.domain.timer.presentation;
+
+import com.nookbook.domain.timer.application.TimerService;
+import com.nookbook.domain.timer.dto.request.UpdateTimerReq;
+import com.nookbook.domain.timer.dto.response.TimerRes;
+import com.nookbook.global.config.security.token.CurrentUser;
+import com.nookbook.global.config.security.token.UserPrincipal;
+import com.nookbook.global.payload.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Timer", description = "타이머 관련 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class TimerController {
+
+    private final TimerService timerService;
+
+    @Operation(summary = "타이머 기록 조회", description = "타이머 기록의 누적 시간 및 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = TimerRes.class)) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    } )
+    @GetMapping("/books/{bookId}/timers")
+    public ResponseEntity<?> getTimerRecord(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "도서의 id를 입력해주세요.", required = true) @PathVariable Long bookId
+    ) {
+        return timerService.getTimerRecords(userPrincipal, bookId);
+    }
+
+    @Operation(summary = "타이머 종료", description = "타이머를 종료하고, 타이머 기록을 변경합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = TimerRes.class)) } ),
+            @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    } )
+    @PatchMapping("/timers/{timerId}")
+    public ResponseEntity<?> endTimerRecord(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "종료하려는 타이머의 id를 입력해주세요.", required = true) @PathVariable Long timerId,
+            @Parameter(description = "시간을 입력해주세요.", required = true) @RequestBody UpdateTimerReq updateTimerReq
+    ) {
+        return timerService.updateTimer(userPrincipal, timerId, updateTimerReq);
+    }
+
+    @Operation(summary = "타이머 시작", description = "타이머를 시작합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class)) } ),
+            @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    } )
+    @PostMapping("/books/{bookId}/timers")
+    public ResponseEntity<?> startTimerRecord(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "도서의 id를 입력해주세요.", required = true) @PathVariable Long bookId
+    ) {
+        return timerService.createTimer(userPrincipal, bookId);
+    }
+}

--- a/src/main/java/com/nookbook/domain/user/application/UserService.java
+++ b/src/main/java/com/nookbook/domain/user/application/UserService.java
@@ -181,11 +181,11 @@ public class UserService {
         String imageName;
         String imageUrl;
         if (isDefaultImage && image==null) {
-            imageName = "default.png";
             imageUrl = "https://nookbook-image-bucket.s3.amazonaws.com/default.png";
+            imageName = "default.png";
         } else {
-            imageName = s3Uploader.uploadImage(image);
-            imageUrl = s3Uploader.getFullPath(imageName);
+            imageUrl = s3Uploader.uploadImage(image);
+            imageName = s3Uploader.extractFileName(imageUrl);
         }
         user.updateImage(imageName, imageUrl);
         ApiResponse apiResponse = ApiResponse.builder()

--- a/src/main/java/com/nookbook/domain/user/application/UserService.java
+++ b/src/main/java/com/nookbook/domain/user/application/UserService.java
@@ -173,18 +173,18 @@ public class UserService {
     }
 
     @Transactional
-    public ResponseEntity<?> updateImage(UserPrincipal userPrincipal, Boolean isDefaultImage, Optional<MultipartFile> image) {
+    public ResponseEntity<?> updateImage(UserPrincipal userPrincipal, Boolean isDefaultImage, MultipartFile image) {
         User user = validUserByUserId(userPrincipal.getId());
         if (!Objects.equals(user.getImageName(), "default.png")) {
             s3Uploader.deleteFile(user.getImageName());
         }
         String imageName;
         String imageUrl;
-        if (isDefaultImage && image.isEmpty()) {
+        if (isDefaultImage && image==null) {
             imageName = "default.png";
             imageUrl = "https://nookbook-image-bucket.s3.amazonaws.com/default.png";
         } else {
-            imageName = s3Uploader.uploadImage(image.get());
+            imageName = s3Uploader.uploadImage(image);
             imageUrl = s3Uploader.getFullPath(imageName);
         }
         user.updateImage(imageName, imageUrl);

--- a/src/main/java/com/nookbook/domain/user/application/UserService.java
+++ b/src/main/java/com/nookbook/domain/user/application/UserService.java
@@ -4,16 +4,13 @@ import com.nookbook.domain.user.domain.Friend;
 import com.nookbook.domain.user.domain.FriendRequestStatus;
 import com.nookbook.domain.user.domain.repository.FriendRepository;
 import com.nookbook.domain.user.dto.request.ExpoPushTokenReq;
-import com.nookbook.domain.user.dto.response.UserExistsRes;
+import com.nookbook.domain.user.dto.response.*;
 import com.nookbook.infrastructure.s3.S3Uploader;
 import com.nookbook.domain.user.domain.User;
 import com.nookbook.domain.user.domain.repository.UserRepository;
 import com.nookbook.domain.user.dto.request.NicknameIdCheckReq;
 import com.nookbook.domain.user.dto.request.NicknameCheckReq;
 import com.nookbook.domain.user.dto.request.UserInfoReq;
-import com.nookbook.domain.user.dto.response.UserInfoRes;
-import com.nookbook.domain.user.dto.response.NicknameCheckRes;
-import com.nookbook.domain.user.dto.response.NicknameIdCheckRes;
 import com.nookbook.global.DefaultAssert;
 import com.nookbook.global.config.security.token.UserPrincipal;
 import com.nookbook.global.payload.ApiResponse;
@@ -21,6 +18,9 @@ import com.nookbook.global.payload.Message;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -240,6 +240,25 @@ public class UserService {
                 .information(Message.builder().message("Expo push token 저장 성공").build())
                 .build();
         return ResponseEntity.ok(apiResponse);
+    }
+
+    public ResponseEntity<?> searchUsers(UserPrincipal userPrincipal, String keyword, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        User user = validUserByUserId(userPrincipal.getId());
+        Page<SearchUserRes> searchUserRes = getAllUsersByKeyword(user, keyword, pageable);
+        return ResponseEntity.ok(ApiResponse.builder()
+                .check(true)
+                .information(searchUserRes)
+                .build());
+    }
+
+    private Page<SearchUserRes> getAllUsersByKeyword(User user, String keyword, Pageable pageable) {
+        Page<User> findUsers = userRepository.findUsersNotInFriendByKeyword(user, keyword, pageable);
+        return findUsers.map(findUser -> SearchUserRes.builder()
+                .userId(findUser.getUserId())
+                .nickname(findUser.getNickname())
+                .imageUrl(findUser.getImageUrl())
+                .build());
     }
 
     private User validUserByUserId(Long userId) {

--- a/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
+++ b/src/main/java/com/nookbook/domain/user/domain/repository/FriendRepository.java
@@ -25,8 +25,6 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     boolean existsBySenderAndReceiver(User user, User targetUser);
 
-    boolean existsByReceiverAndSender(User targetUser, User user);
-
     @Query("SELECT f FROM Friend f " +
             "WHERE (" +
             "    (f.sender = :user AND (f.receiver.nickname LIKE %:keyword%  OR f.receiver.nicknameId LIKE %:keyword% )) " +

--- a/src/main/java/com/nookbook/domain/user/dto/request/FriendRequestDecisionReq.java
+++ b/src/main/java/com/nookbook/domain/user/dto/request/FriendRequestDecisionReq.java
@@ -1,0 +1,13 @@
+package com.nookbook.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FriendRequestDecisionReq {
+
+    @Schema(type = "boolean", description = "요청 수락 여부로, true: 수락 / false: 거절", example = "true")
+    private boolean isAccept;
+}

--- a/src/main/java/com/nookbook/domain/user/dto/request/FriendRequestReq.java
+++ b/src/main/java/com/nookbook/domain/user/dto/request/FriendRequestReq.java
@@ -1,0 +1,13 @@
+package com.nookbook.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FriendRequestReq {
+
+    @Schema(description = "친구 요청을 보낼 사용자의 userId", example = "1")
+    private Long userId;
+}

--- a/src/main/java/com/nookbook/domain/user/presentation/FriendController.java
+++ b/src/main/java/com/nookbook/domain/user/presentation/FriendController.java
@@ -1,14 +1,10 @@
 package com.nookbook.domain.user.presentation;
 
-import com.nookbook.domain.book.applicaiton.BookService;
-import com.nookbook.domain.book.dto.response.MostReadCategoriesRes;
-import com.nookbook.domain.note.application.NoteService;
-import com.nookbook.domain.note.dto.response.OtherUserNoteListRes;
 import com.nookbook.domain.user.application.FriendService;
-import com.nookbook.domain.user.application.UserService;
+import com.nookbook.domain.user.dto.request.FriendRequestDecisionReq;
+import com.nookbook.domain.user.dto.request.FriendRequestReq;
 import com.nookbook.domain.user.dto.response.FriendsRequestRes;
 import com.nookbook.domain.user.dto.response.SearchUserRes;
-import com.nookbook.domain.user.dto.response.UserInfoRes;
 import com.nookbook.global.config.security.token.CurrentUser;
 import com.nookbook.global.config.security.token.UserPrincipal;
 import com.nookbook.global.payload.ErrorResponse;
@@ -23,46 +19,25 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.security.InvalidParameterException;
-import java.util.Objects;
-import java.util.Optional;
-
 @Tag(name = "Friend", description = "Friend API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/friends")
 public class FriendController {
 
-    private final UserService userService;
-    private final BookService bookService;
     private final FriendService friendService;
-    private final NoteService noteService;
 
-    @Operation(summary = "친구 추가 - 검색", description = "사용자 전체를 대상으로 단어를 검색하여 조회합니다.")
+    @Operation(summary = "친구 목록 조회 및 검색", description = "친구 목록을 조회 및 검색합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = SearchUserRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @GetMapping("/friend/all")
-    public ResponseEntity<?> searchAllUsers(
-            @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "검색하고자 하는 단어를 입력해주세요.") @RequestParam String keyword,
-            @Parameter(description = "페이지의 숫자입니다. 페이지는 0부터 시작합니다.") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "페이지 내 요소의 개수입니다.") @RequestParam(defaultValue = "20") int size
-    ) {
-        return friendService.searchUsers(userPrincipal, keyword, page, size);
-    }
-
-    @Operation(summary = "친구 목록 - 조회", description = "친구 목록을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = SearchUserRes.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    })
-    @GetMapping("/friend")
+    @GetMapping("")
     public ResponseEntity<?> getFriends(
-            @CurrentUser UserPrincipal userPrincipal
+            @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "검색하고자 하는 단어를 입력해주세요.") @RequestParam String keyword
     ) {
-        return friendService.getFriends(userPrincipal, null);
+        return friendService.getFriends(userPrincipal, keyword);
     }
 
     @Operation(summary = "친구 추가 - 내가 보낸/받은 요청 목록 조회", description = "내가 보낸/받은 요청 목록을 조회합니다.")
@@ -70,7 +45,7 @@ public class FriendController {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = FriendsRequestRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @GetMapping("/friend/pending")
+    @GetMapping("/requests")
     public ResponseEntity<?> getFriendsRequest(
             @CurrentUser UserPrincipal userPrincipal
     ) {
@@ -82,12 +57,12 @@ public class FriendController {
             @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
             @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @PostMapping("/friend/pending/{userId}")
+    @PostMapping("/requests")
     public ResponseEntity<?> sendFriendRequest(
             @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.", required = true) @PathVariable Long userId
-    ) {
-        return friendService.sendFriendRequest(userPrincipal, userId);
+            @Parameter(description = "Schemas의 FriendRequestReq를 참고해주세요.", required = true) @RequestBody FriendRequestReq friendRequestReq
+            ) {
+        return friendService.sendFriendRequest(userPrincipal, friendRequestReq);
     }
 
     @Operation(summary = "친구 수락/거절", description = "요청을 수락하거나 거절합니다.")
@@ -95,13 +70,13 @@ public class FriendController {
             @ApiResponse(responseCode = "200", description = "저장 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
             @ApiResponse(responseCode = "400", description = "저장 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @PutMapping("/friend/pending/{friendId}")
+    @PatchMapping("/requests/{friendId}")
     public ResponseEntity<?> acceptOrRejectFriendRequest(
             @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "친구 요청 목록에서 조회한 friendId를 입력해주세요.", required = true) @PathVariable Long friendId,
-            @Parameter(description = "요청의 수락 여부입니다. true: 수락, false: 거절", required = true) @RequestParam boolean isAccept
-    ) {
-        return friendService.updateFriendRequestStatus(userPrincipal, friendId, isAccept);
+            @Parameter(description = "Schemas의 FriendRequestDecisionReq를 참고해주세요.", required = true) @RequestBody FriendRequestDecisionReq decisionReq
+            ) {
+        return friendService.updateFriendRequestStatus(userPrincipal, friendId, decisionReq);
     }
 
     @Operation(summary = "친구 요청 취소", description = "내가 보낸 친구 요청을 취소합니다.")
@@ -109,7 +84,7 @@ public class FriendController {
             @ApiResponse(responseCode = "200", description = "취소 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
             @ApiResponse(responseCode = "400", description = "취소 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @DeleteMapping ("/friend/pending/{friendId}")
+    @DeleteMapping ("/requests/{friendId}")
     public ResponseEntity<?> cancelFriendRequest(
             @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "친구 요청 목록에서 조회한 friendId를 입력해주세요.", required = true) @PathVariable Long friendId
@@ -122,7 +97,7 @@ public class FriendController {
             @ApiResponse(responseCode = "200", description = "삭제 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
             @ApiResponse(responseCode = "400", description = "삭제 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @DeleteMapping ("/friend/{friendId}")
+    @DeleteMapping ("/{friendId}")
     public ResponseEntity<?> deleteFriendRequest(
             @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "친구 목록에서 조회한 friendId를 입력해주세요.", required = true) @PathVariable Long friendId
@@ -130,64 +105,4 @@ public class FriendController {
         return friendService.deleteFriendRequest(userPrincipal, friendId, true);
     }
 
-    // 친구페이지
-    @Operation(summary = "독서 통계 조회", description = "친구페이지의 독서 통계(카테고리, 연도 및 월별 선택)를 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = MostReadCategoriesRes.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    })
-    @GetMapping("/user/{userId}/report")
-    public ResponseEntity<?> findReadingReport(
-            @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "독서 통계를 조회하고자 하는 사용자의 id를 입력해주세요.", required = true) @PathVariable Long userId,
-            @Parameter(description = "독서 통계의 종류입니다. category: 카테고리별(기본) , year: 연도별", required = true) @RequestParam(defaultValue = "category") String type,
-            @Parameter(description = "type이 year인 경우, 독서 통계를 확인하려는 연도를 입력해주세요") @RequestParam(required = false) Optional<Integer> targetYear
-    ) {
-        if (Objects.equals(type, "category")) {
-            return bookService.countReadBooksByCategory(userPrincipal, userId);
-        } else if (Objects.equals(type, "year") && targetYear.isPresent()) {
-            return bookService.countReadBooksByYear(userPrincipal, userId, targetYear);
-        } else throw new InvalidParameterException("유효한 파라미터가 아닙니다.");
-    }
-
-    @Operation(summary = "사용자 정보 조회", description = "친구페이지의 정보(아이디, 닉네임, 프로필 이미지, 친구 수, 친구 요청 상태)를 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = UserInfoRes.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    })
-    @GetMapping("/user/{userId}")
-    public ResponseEntity<?> findUserInformation(
-            @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.", required = true) @PathVariable Long userId
-    ) {
-        return userService.getUserInfo(userPrincipal, userId);
-    }
-
-    @Operation(summary = "기록 전체보기 목록 조회 및 검색", description = "친구페이지의 기록 전체보기 목록 조회 또는 검색하여 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = OtherUserNoteListRes.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    })
-    @GetMapping("/user/{userId}/note")
-    public ResponseEntity<?> findUserAllNotes(
-            @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.", required = true) @PathVariable Long userId,
-            @Parameter(description = "검색하고자 하는 단어를 입력해주세요. 없다면 입력하지 않습니다.") @RequestParam(required = false) String keyword
-    ) {
-        return noteService.getUserPageNoteList(userPrincipal, userId, keyword);
-    }
-
-    @Operation(summary = "기록 전체보기 상세 조회", description = "친구페이지의 기록 전체보기에서 도서를 선택하여 상세 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = OtherUserNoteListRes.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    })
-    @GetMapping("/user/{userId}/note/book/{bookId}")
-    public ResponseEntity<?> findUserAllNotesDetail(
-            @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "조회하고자 하는 사용자의 id를 입력해주세요.", required = true) @PathVariable Long userId,
-            @Parameter(description = "조회하고자 하는 노트의 **도서 id**를 입력해주세요.", required = true) @PathVariable Long bookId
-    ) {
-        return noteService.getUserPageNoteListByBookId(userPrincipal, userId, bookId);
-    }
 }

--- a/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
+++ b/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
@@ -73,11 +73,23 @@ public class MyPageController {
     @PutMapping("/image")
     public ResponseEntity<?> updateImage(
             @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "기본 이미지 사용 여부", required = true) @RequestPart Boolean isDefaultImage,
-            @Parameter(description = "변경할 프로필 이미지 파일") @RequestPart Optional<MultipartFile> image
+            @Parameter(description = "변경할 프로필 이미지 파일") @RequestPart MultipartFile image
     ) {
-        return userService.updateImage(userPrincipal, isDefaultImage, image);
+        return userService.updateImage(userPrincipal, false, image);
     }
+
+    @Operation(summary = "사용자 프로필 이미지를 기본으로 변경", description = "사용자의 프로필 이미지를 기본으로 변경합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "변경 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "변경 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @PutMapping("/image/default")
+    public ResponseEntity<?> updateDefaultImage(
+            @CurrentUser UserPrincipal userPrincipal
+    ) {
+        return userService.updateImage(userPrincipal, true, null);
+    }
+
 
     @Operation(summary = "독서 통계", description = "마이페이지의 독서 통계(카테고리, 연도 및 월별)를 조회합니다.")
     @ApiResponses(value = {

--- a/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
+++ b/src/main/java/com/nookbook/domain/user/presentation/MyPageController.java
@@ -44,7 +44,7 @@ public class MyPageController {
             @ApiResponse(responseCode = "200", description = "변경 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
             @ApiResponse(responseCode = "400", description = "변경 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @PutMapping("/nickname-id")
+    @PatchMapping("/nickname-id")
     public ResponseEntity<?> updateNicknameId(
             @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "변경할 아이디 입력값", required = true) @Valid @RequestBody NicknameIdCheckReq nicknameIdCheckReq
@@ -57,7 +57,7 @@ public class MyPageController {
             @ApiResponse(responseCode = "200", description = "변경 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
             @ApiResponse(responseCode = "400", description = "변경 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @PutMapping("/nickname")
+    @PatchMapping("/nickname")
     public ResponseEntity<?> updateNickname(
             @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "변경할 닉네임 입력값", required = true) @Valid @RequestBody NicknameCheckReq nicknameCheckReq
@@ -70,7 +70,7 @@ public class MyPageController {
             @ApiResponse(responseCode = "200", description = "변경 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
             @ApiResponse(responseCode = "400", description = "변경 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @PutMapping("/image")
+    @PatchMapping("/profile-image")
     public ResponseEntity<?> updateImage(
             @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "변경할 프로필 이미지 파일") @RequestPart MultipartFile image
@@ -83,7 +83,7 @@ public class MyPageController {
             @ApiResponse(responseCode = "200", description = "변경 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
             @ApiResponse(responseCode = "400", description = "변경 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @PutMapping("/image/default")
+    @PatchMapping("/profile-image/default")
     public ResponseEntity<?> updateDefaultImage(
             @CurrentUser UserPrincipal userPrincipal
     ) {
@@ -96,7 +96,7 @@ public class MyPageController {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = MostReadCategoriesRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @GetMapping("/report")
+    @GetMapping("/reports")
     public ResponseEntity<?> findMyReadingReport(
             @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "독서 통계의 종류입니다. category: 카테고리별(기본) , year: 연도별", required = true) @RequestParam(defaultValue = "category") String type,
@@ -126,25 +126,12 @@ public class MyPageController {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = OtherUserNoteListRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @GetMapping("/note")
+    @GetMapping("/books")
     public ResponseEntity<?> findMyAllNotes(
             @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "검색하고자 하는 단어를 입력해주세요. 없다면 입력하지 않습니다.") @RequestParam(required = false) String keyword
     ) {
         return noteService.getUserPageNoteList(userPrincipal, userPrincipal.getId(), keyword);
-    }
-
-    @Operation(summary = "기록 전체보기 상세 조회", description = "마이페이지의 기록 전체보기에서 도서를 선택하여 상세 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = OtherUserNoteListRes.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    })
-    @GetMapping("/note/book/{bookId}")
-    public ResponseEntity<?> findMyAllNotesDetail(
-            @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "조회하고자 하는 노트의 **도서 id**를 입력해주세요.", required = true) @PathVariable Long bookId
-    ) {
-        return noteService.getUserPageNoteListByBookId(userPrincipal, userPrincipal.getId(), bookId);
     }
 
 }

--- a/src/main/java/com/nookbook/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/nookbook/global/exception/GlobalExceptionHandler.java
@@ -12,10 +12,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DefaultException.class)
     public ResponseEntity<ErrorResponse> handleDefaultException(DefaultException ex) {
-        ErrorCode errorCode = ex.getErrorCode();
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .code(errorCode).build();
-        return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(errorCode.getStatus()));
+        return ResponseEntity
+                .status(ex.getErrorCode().getStatus())
+                .body(ErrorResponse.of(ex.getErrorCode(), ex.getMessage()));
     }
 
     @ExceptionHandler(NotFoundException.class)

--- a/src/main/java/com/nookbook/infrastructure/s3/S3Uploader.java
+++ b/src/main/java/com/nookbook/infrastructure/s3/S3Uploader.java
@@ -64,6 +64,9 @@ public class S3Uploader {
         return "https://" + bucket + ".s3.amazonaws.com/" + fileName;
     }
 
+    public String extractFileName(String fullPath) {
+        return fullPath.substring(fullPath.lastIndexOf("/") + 1);
+    }
 
     public void deleteFile(String fileName) {
         try {
@@ -71,10 +74,6 @@ public class S3Uploader {
         } catch (AmazonServiceException e) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다.");
         }
-    }
-
-    public String extractImageNameFromUrl(String imageUrl) {
-        return imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
     }
 
 }


### PR DESCRIPTION
## 👑 Summary
> 어떤 내용의 PR인가요?
- 도서(+키워드), 타이머, 노트, 마이페이지, 친구의 URL을 RESTful하게 변경했습니다.

## 🫧 To be noted
> PR을 검토할 때 확인해야 할 사항이 있나요?
- 도메인별로 컨트롤러를 분리했습니다. 
- 일부 자원만 변경하는 용도에 맞게, @PutMapping이던 API 일부를 **@PatchMapping**으로 변경했습니다.
- 친구 목록 조회 API에 검색 기능이 있다는 걸 뒤늦게 알아서... 추가했습니다.
- `DefaultAssert`나 `DefaultException`에서 커스텀 메시지 사용 시 반영되지 않는 오류 수정했습니다. GlobalExceptionHandler 코드 참고해주세요!
- 프론트에서 요청한 사안인 프로필 이미지 S3 업로드 시 오류 수정 및 프로필 변경 API(커스텀/기본 분리) 수정해두었습니다.

## 💫 issue number
> 이슈 번호를 작성해주새요
- resolve #182 

## ☑️ Checklist
> PR 요청 시 체크해주세요.
- [x] label
- [x] issue number
- [x] conflict resolve

## 💡 Comment
> 전달하고 싶은 내용이 있나요?
- URL 변경사항 노션에 기재해두었습니다! (기존에 만들어두신 데이터베이스 사용하고 있습니다)
- `BookController`에 존재하던 `timer`, `keyword`를 각각의 컨트롤러로 분리했습니다.
- `FriendController`에 존재하던 타 사용자 관련 기능(프로필 조회, 독서 통계 조회 등)을 `UserController`로 이동했습니다. 본래는 관련도가 있는 친구 관련 컨트롤러에 두려고 했으나 경로에서 `friendId`가 아닌 `userId`만을 사용하는 점을 고려해 해당 부분을 변경했습니다.
### 파라미터 형식이 변경된 API 목록
- 경로에 파라미터 추가: 노트 생성
- 경로에서 파라미터 제거: 타이머 종료
- 파라미터를 dto로 변경: 친구 요청, 친구 요청 수락/거절
