### PR TITLE
[REFACTOR] 베스트셀러 API 호출 방식 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,11 +38,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
-
 
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.1.0'
     testImplementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-api', version: '2.1.0'

--- a/src/main/java/com/nookbook/domain/book/applicaiton/AladinService.java
+++ b/src/main/java/com/nookbook/domain/book/applicaiton/AladinService.java
@@ -1,0 +1,109 @@
+package com.nookbook.domain.book.applicaiton;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AladinService {
+
+    // ttb 키 value로
+    @Value("${aladin.ttb.key}")
+    private String KEY;
+
+    @Value("${aladin.search-url}")
+    private String SEARCH_URL;
+
+    @Value("${aladin.list-url}")
+    private String LIST_URL;
+
+    @Value("${aladin.find-url}")
+    private String FIND_URL;
+
+    public String callAladinSearchBooks(String keyword, int page) {
+        RestTemplate restTemplate = new RestTemplate();
+        // 기본 헤더 설정 (필요에 따라)
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+        HttpEntity<String> httpEntity = new HttpEntity<>(headers);
+        URI requestUrl = UriComponentsBuilder
+                .fromUriString(SEARCH_URL)
+                .queryParam("ttbkey", KEY)
+                .queryParam("Query", keyword)
+                .queryParam("QueryType", "Keyword")
+                .queryParam("QueryType", "Publisher")
+                .queryParam("start", page)
+                .queryParam("MaxResults", 10)
+                .queryParam("Cover", "Big")
+                .queryParam("output", "JS")
+                .queryParam("Version", 20131101)
+                .build()
+                .encode(StandardCharsets.UTF_8)
+                .toUri();
+        // API 호출 및 응답 처리
+        ResponseEntity<String> responseEntity = restTemplate.exchange(requestUrl, HttpMethod.GET, httpEntity, String.class);
+        return responseEntity.getBody();
+    }
+
+    // 베스트셀러 + 카테고리
+    // 종합(0), 소설(1), 경제/경영(170), 자기계발(336), 시(50940), 에세이(55889), 인문/교양(656), 취미/실용(55890), 매거진(2913)
+    public String callAladinBestSellers(int page, int category, int size) {
+        RestTemplate restTemplate = new RestTemplate();
+        // 기본 헤더 설정 (필요에 따라)
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+        HttpEntity<String> httpEntity = new HttpEntity<>(headers);
+        URI requestUrl = UriComponentsBuilder
+                .fromUriString(LIST_URL)
+                .queryParam("ttbkey", KEY)
+                .queryParam("QueryType", "Bestseller")
+                .queryParam("SearchTarget", "Book")
+                .queryParam("start", page)
+                .queryParam("MaxResults", size)
+                .queryParam("Cover", "Big")
+                .queryParam("CategoryId", category)
+                .queryParam("output", "JS")
+                .queryParam("Version", 20131101)
+                .build()
+                .encode(StandardCharsets.UTF_8)
+                .toUri();
+        // API 호출 및 응답 처리
+        ResponseEntity<String> responseEntity = restTemplate.exchange(requestUrl, HttpMethod.GET, httpEntity, String.class);
+        return responseEntity.getBody();
+    }
+
+    public String callAladinBookDetail(String isbn13) {
+        RestTemplate restTemplate = new RestTemplate();
+        // 기본 헤더 설정 (필요에 따라)
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+        HttpEntity<String> httpEntity = new HttpEntity<>(headers);
+
+        // 요청 URL 구성
+        URI requestUrl = UriComponentsBuilder
+                .fromUriString(FIND_URL)
+                .queryParam("ttbkey", KEY)
+                .queryParam("ItemId", isbn13)
+                .queryParam("itemIdType", "ISBN13")
+                .queryParam("Cover", "Big")
+                .queryParam("output", "JS")
+                .queryParam("Version", 20131101)
+                .queryParam("OptResult", "Toc,fulldescription")
+                .build()
+                .encode(StandardCharsets.UTF_8)
+                .toUri();
+        // API 호출 및 응답 처리
+        ResponseEntity<String> responseEntity = restTemplate.exchange(requestUrl, HttpMethod.GET, httpEntity, String.class);
+        return responseEntity.getBody();
+    }
+
+}

--- a/src/main/java/com/nookbook/domain/book/applicaiton/BestSellerCacheService.java
+++ b/src/main/java/com/nookbook/domain/book/applicaiton/BestSellerCacheService.java
@@ -1,0 +1,86 @@
+package com.nookbook.domain.book.applicaiton;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nookbook.domain.book.dto.response.BestSellerRes;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.event.EventListener;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BestSellerCacheService {
+
+    private final CacheManager cacheManager;
+    private final AladinService aladinService;
+
+    private static final List<Integer> CATEGORIES = List.of(0, 1, 170, 336, 50940, 55889, 656, 55890, 2913);
+    private static final String CACHE_NAME = "bestSellers";
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void loadInitialCache() {
+        retryableRefreshAll();
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void scheduledRefresh() {
+        log.info("🔁 [Scheduler] refreshAll() 실행됨 - {}", System.currentTimeMillis());
+        retryableRefreshAll();
+    }
+
+    @Retryable(
+            value = { Exception.class },
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 5000)
+    )
+    public void retryableRefreshAll() {
+        refreshAllCategoriesAndPages(10, CATEGORIES, 100);
+    }
+
+    @Cacheable(value = CACHE_NAME, key = "#category + '-' + #page")
+    public BestSellerRes getBestSellerFromCache(int page, int category, int size) {
+        return getBestSellerFromApi(page, category, size);
+    }
+
+    public BestSellerRes getBestSellerFromApi(int page, int category, int size) {
+        String json = aladinService.callAladinBestSellers(page, category, size);
+        return convertToBestSellerRes(json);
+    }
+
+    public void refreshCategoryAndPage(int page, int category, int size) {
+        BestSellerRes result = getBestSellerFromApi(page, category, size);
+        String cacheKey = category + "-" + page;
+        cacheManager.getCache(CACHE_NAME).put(cacheKey, result);
+    }
+
+    public void refreshAllCategoriesAndPages(int totalPages, List<Integer> categories, int size) {
+        for (int category : categories) {
+            for (int page = 1; page <= totalPages; page++) {
+                refreshCategoryAndPage(category, page, size);
+            }
+        }
+    }
+
+    private BestSellerRes convertToBestSellerRes(String json) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            // JSON 문자열을 BestSellerRes 객체로 변환
+            return objectMapper.readValue(json, BestSellerRes.class);
+        } catch (Exception e) {
+            System.err.println("Error converting JSON to BestSellerRes: " + e.getMessage());
+            e.printStackTrace();
+            return new BestSellerRes(); // 오류 발생 시 빈 객체 반환
+        }
+    }
+}

--- a/src/main/java/com/nookbook/domain/book/applicaiton/BookService.java
+++ b/src/main/java/com/nookbook/domain/book/applicaiton/BookService.java
@@ -18,15 +18,10 @@ import com.nookbook.global.DefaultAssert;
 import com.nookbook.global.config.security.token.UserPrincipal;
 import com.nookbook.global.payload.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -43,20 +38,9 @@ public class BookService {
     private final UserBookRepository userBookRepository;
     private final CollectionBookRepository collectionBookRepository;
 
+    private final AladinService aladinService;
+    private final BestSellerCacheService bestSellerCacheService;
     private final KeywordService keywordService;
-
-    // ttb 키 value로
-    @Value("${aladin.ttb.key}")
-    private String KEY;
-
-    @Value("${aladin.search-url}")
-    private String SEARCH_URL;
-
-    @Value("${aladin.list-url}")
-    private String LIST_URL;
-
-    @Value("${aladin.find-url}")
-    private String FIND_URL;
 
     // 검색
     @Transactional
@@ -64,69 +48,16 @@ public class BookService {
         User user = validUserById(userPrincipal.getId());
         // 검색 키워드 저장
         keywordService.saveKeyword(user, keyword);
-
-        RestTemplate restTemplate = new RestTemplate();
-        // 기본 헤더 설정 (필요에 따라)
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
-        HttpEntity<String> httpEntity = new HttpEntity<>(headers);
-
-        // 요청 URL 구성
-        URI requestUrl = UriComponentsBuilder
-                .fromUriString(SEARCH_URL)
-                .queryParam("ttbkey", KEY)
-                .queryParam("Query", keyword)
-                .queryParam("QueryType", "Keyword")
-                .queryParam("QueryType", "Publisher")
-                .queryParam("start", page)
-                .queryParam("MaxResults", 10)
-                .queryParam("Cover", "Big")
-                .queryParam("output", "JS")
-                .queryParam("Version", 20131101)
-                .build()
-                .encode(StandardCharsets.UTF_8)
-                .toUri();
-        // API 호출 및 응답 처리
-        ResponseEntity<String> responseEntity = restTemplate.exchange(requestUrl, HttpMethod.GET, httpEntity, String.class);
-        String responseBody = responseEntity.getBody();
-
+        String responseBody = aladinService.callAladinSearchBooks(keyword, page);
         // JSON 파싱 및 DTO 변환
         SearchRes searchRes = convertToSearchRes(responseBody);
-
         return ResponseEntity.ok(searchRes);
     }
 
     // 베스트셀러 + 카테고리
     // 종합(0), 소설(1), 경제/경영(170), 자기계발(336), 시(50940), 에세이(55889), 인문/교양(656), 취미/실용(55890), 매거진(2913)
     public ResponseEntity<?> getBestSellerByCategory(int page, int category, int size) {
-        RestTemplate restTemplate = new RestTemplate();
-        // 기본 헤더 설정 (필요에 따라)
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
-        HttpEntity<String> httpEntity = new HttpEntity<>(headers);
-
-        // 요청 URL 구성
-        URI requestUrl = UriComponentsBuilder
-                .fromUriString(LIST_URL)
-                .queryParam("ttbkey", KEY)
-                .queryParam("QueryType", "Bestseller")
-                .queryParam("SearchTarget", "Book")
-                .queryParam("start", page)
-                .queryParam("MaxResults", size)
-                .queryParam("Cover", "Big")
-                .queryParam("CategoryId", category)
-                .queryParam("output", "JS")
-                .queryParam("Version", 20131101)
-                .build()
-                .encode(StandardCharsets.UTF_8)
-                .toUri();
-        // API 호출 및 응답 처리
-        ResponseEntity<String> responseEntity = restTemplate.exchange(requestUrl, HttpMethod.GET, httpEntity, String.class);
-        String responseBody = responseEntity.getBody();
-
-        // JSON 파싱 및 DTO 변환
-        BestSellerRes bestSellerRes = convertToBestSellerRes(responseBody);
-
+        BestSellerRes bestSellerRes = bestSellerCacheService.getBestSellerFromCache(page, category, size);
         return ResponseEntity.ok(bestSellerRes);
     }
 
@@ -211,29 +142,7 @@ public class BookService {
     }
 
     private BookDetailRes getBookInfoByISBN(String isbn13) {
-        RestTemplate restTemplate = new RestTemplate();
-        // 기본 헤더 설정 (필요에 따라)
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
-        HttpEntity<String> httpEntity = new HttpEntity<>(headers);
-
-        // 요청 URL 구성
-        URI requestUrl = UriComponentsBuilder
-                .fromUriString(FIND_URL)
-                .queryParam("ttbkey", KEY)
-                .queryParam("ItemId", isbn13)
-                .queryParam("itemIdType", "ISBN13")
-                .queryParam("Cover", "Big")
-                .queryParam("output", "JS")
-                .queryParam("Version", 20131101)
-                .queryParam("OptResult", "Toc,fulldescription")
-                .build()
-                .encode(StandardCharsets.UTF_8)
-                .toUri();
-        // API 호출 및 응답 처리
-        ResponseEntity<String> responseEntity = restTemplate.exchange(requestUrl, HttpMethod.GET, httpEntity, String.class);
-        String responseBody = responseEntity.getBody();
-
+        String responseBody = aladinService.callAladinBookDetail(isbn13);
         // JSON 파싱 및 DTO 변환
         return convertToBookDetailRes(responseBody);
     }
@@ -247,18 +156,6 @@ public class BookService {
             System.err.println("Error converting JSON to SearchRes: " + e.getMessage());
             e.printStackTrace();
             return new SearchRes(); // 오류 발생 시 빈 객체 반환
-        }
-    }
-
-    private BestSellerRes convertToBestSellerRes(String json) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        try {
-            // JSON 문자열을 BestSellerRes 객체로 변환
-            return objectMapper.readValue(json, BestSellerRes.class);
-        } catch (Exception e) {
-            System.err.println("Error converting JSON to BestSellerRes: " + e.getMessage());
-            e.printStackTrace();
-            return new BestSellerRes(); // 오류 발생 시 빈 객체 반환
         }
     }
 

--- a/src/main/java/com/nookbook/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/nookbook/global/config/security/SecurityConfig.java
@@ -80,7 +80,7 @@ public class SecurityConfig {
                         .permitAll()
                         .requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**")
                         .permitAll()
-                        .requestMatchers("/auth/login", "/api/v1/user/exists")
+                        .requestMatchers("/auth/login", "/api/v1/users/exists")
                         .permitAll()
                         .anyRequest()
                         .authenticated())

--- a/src/main/java/com/nookbook/infrastructure/cache/config/CaffeineConfig.java
+++ b/src/main/java/com/nookbook/infrastructure/cache/config/CaffeineConfig.java
@@ -1,0 +1,26 @@
+package com.nookbook.infrastructure.cache.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@EnableCaching
+public class CaffeineConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("bestSellers");
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+                .expireAfterWrite(25, TimeUnit.HOURS) // 갱신 주기(24시간) 보다 넉넉하게
+                .maximumSize(100)
+        );
+        return cacheManager;
+    }
+}
+

--- a/src/main/java/com/nookbook/infrastructure/cache/config/RetryConfig.java
+++ b/src/main/java/com/nookbook/infrastructure/cache/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.nookbook.infrastructure.cache.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@EnableRetry
+@Configuration
+public class RetryConfig {
+}


### PR DESCRIPTION
## 👑 Summary
> 어떤 내용의 PR인가요?
- 베스트셀러 API 호출 방식 변경
```
[기존 방식]
사용자 → API 서버 → 외부 API → API 서버 → 사용자

--------------------------------------

[변경 방식]
사용자 → API 서버 → 캐시 → API 서버 → 사용자
                     ↑
                 외부 API
                     ↓
                캐시에 저장
```

## 🫧 To be noted
> PR을 검토할 때 확인해야 할 사항이 있나요?
- 단일서버인 점, 캐시할 데이터의 크기가 크지 않은 점을 고려해 로컬 캐시인 [Caffeine Cache](https://velog.io/@komment/%EC%BA%90%EC%8B%9C%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%98%EC%97%AC-%EB%B6%80%ED%95%98%EB%A5%BC-%EC%A4%84%EC%9D%B4%EA%B3%A0-%EC%84%B1%EB%8A%A5%EC%9D%84-%EA%B0%9C%EC%84%A0%ED%95%98%EC%9E%90) 사용했습니다
- `bookService`에서 알라딘 호출 관련 로직을 `aladinService`로, 베스트셀러 캐시 관련한 로직은 `bestSellerCacheService`로 분리했습니다.

## 💫 issue number
> 이슈 번호를 작성해주새요
- resolve #193

## ☑️ Checklist
> PR 요청 시 체크해주세요.
- [x] label
- [x] issue number
- [x] conflict resolve

## 💡 Comment
> 전달하고 싶은 내용이 있나요?
- `SecurityConfig`에서 `/api/v1/user/exists`를 `/api/v1/users/exists`로 변경했습니다.
- 캐시 호출 방식: 서버 시작 시 최초 1회 호출하며, 기본적으로는 매일 자정 1회씩 호출하여 데이터를 변경합니다. 