### PR TITLE
[FEAT] 캘린더 조회 기능 확장에 따른 API 통합

### DIFF
--- a/src/main/java/com/nookbook/domain/challenge/application/ChallengeService.java
+++ b/src/main/java/com/nookbook/domain/challenge/application/ChallengeService.java
@@ -447,6 +447,7 @@ public class ChallengeService {
 
         List<ParticipantRes> participantResList = participants.stream()
                 .map(participant -> ParticipantRes.builder()
+                        .userId(participant.getUser().getUserId()) // 참가자 User ID
                         .participantId(participant.getParticipantId()) // 참가자 ID
                         .participantNickname((participant.getUser().getNickname())) // 참가자 닉네임
                         .participantImage(participant.getUser().getImageUrl()) // 참가자 프로필 이미지

--- a/src/main/java/com/nookbook/domain/challenge/dto/response/ParticipantRes.java
+++ b/src/main/java/com/nookbook/domain/challenge/dto/response/ParticipantRes.java
@@ -11,6 +11,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 public class ParticipantRes {
+    @Schema(type = "Long", example = "1", description = "사용자 ID")
+    private Long userId;
 
     @Schema(type = "Long", example = "1", description = "참여자 ID")
     private Long participantId;

--- a/src/main/java/com/nookbook/domain/challenge/presentation/ChallengeController.java
+++ b/src/main/java/com/nookbook/domain/challenge/presentation/ChallengeController.java
@@ -242,12 +242,14 @@ public class ChallengeController {
 
     // 챌린지 참가자의 독서 기록 정보 조회 API
     // 날짜 형식: 2021-11-01 또는 2021-11
+    // 삭제된 API
     @Operation(summary = "챌린지 참가자의 날짜별 독서 기록 조회", description = "챌린지 참가자의 날짜별 독서 기록을 조회합니다.")
     @GetMapping("/participants/{participantId}/calendar/{date}")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "독서 캘린더 조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = DailyUserBookCalendarRes.class)) } ),
             @ApiResponse(responseCode = "400", description = "독서 캘린더 조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     } )
+    @Deprecated
     public ResponseEntity<?> getUserBookCalendar(
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "참가자 ID를 입력해주세요.", required = true) @PathVariable Long participantId,

--- a/src/main/java/com/nookbook/domain/collection/presentation/CollectionController.java
+++ b/src/main/java/com/nookbook/domain/collection/presentation/CollectionController.java
@@ -45,7 +45,7 @@ public class CollectionController {
         return collectionService.createCollection(userPrincipal, collectionCreateReq);
     }
 
-    @Operation(summary = "컬렉션 목록 조회 API", description = "유저의 컬렉션 목록을 조회하는 API입니다.")
+    @Operation(summary = "사용자의 컬렉션 목록 조회 API", description = "유저의 컬렉션 목록을 조회하는 API입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "컬렉션 목록 조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = CollectionListRes.class))}),
             @ApiResponse(responseCode = "400", description = "컬렉션 목록 조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
@@ -83,6 +83,8 @@ public class CollectionController {
     ) {
         return collectionService.getCollectionBooks(userPrincipal, collectionId);
     }
+
+
 
     @Operation(summary = "컬렉션 도서 삭제 API", description = "컬렉션에 등록된 도서를 삭제하는 API입니다.")
     @ApiResponses(value = {
@@ -169,6 +171,8 @@ public class CollectionController {
         collectionService.moveBookToAnotherCollection(userPrincipal, collectionId, targetCollectionId, bookIdListReq);
         return ResponseEntity.ok(CommonApiResponse.success("도서가 컬렉션 간에 성공적으로 이동되었습니다."));
     }
+
+
 
 
 }

--- a/src/main/java/com/nookbook/domain/user/presentation/UserController.java
+++ b/src/main/java/com/nookbook/domain/user/presentation/UserController.java
@@ -10,6 +10,8 @@ import com.nookbook.domain.user.dto.request.NicknameIdCheckReq;
 import com.nookbook.domain.user.dto.request.NicknameCheckReq;
 import com.nookbook.domain.user.dto.request.UserInfoReq;
 import com.nookbook.domain.user.dto.response.*;
+import com.nookbook.domain.user_book.application.UserBookService;
+import com.nookbook.domain.user_book.dto.response.DailyUserBookCalendarRes;
 import com.nookbook.global.config.security.token.CurrentUser;
 import com.nookbook.global.config.security.token.UserPrincipal;
 import com.nookbook.global.payload.ErrorResponse;
@@ -39,6 +41,7 @@ public class UserController {
     private final UserService userService;
     private final NoteService noteService;
     private final BookService bookService;
+    private final UserBookService userBookService;
 
     @Operation(summary = "기존 사용자 여부 확인", description = "기존에 가입된 사용자인지 확인합니다.")
     @ApiResponses(value = {
@@ -182,5 +185,23 @@ public class UserController {
             @Parameter(description = "조회하고자 하는 노트의 **도서 id**를 입력해주세요.", required = true) @PathVariable Long bookId
     ) {
         return noteService.getUserPageNoteListByBookId(userPrincipal, userId, bookId);
+    }
+
+
+    // 특정 유저의 독서 기록 정보 조회 API
+    // 날짜 형식: 2021-11-01 또는 2021-11
+    @Operation(summary = "특정 유저의 날짜별 독서 기록 조회", description = "특정 유저의 날짜별 독서 기록을 조회합니다.")
+    @GetMapping("/{userId}/calendar/{date}")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "독서 캘린더 조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = DailyUserBookCalendarRes.class)) } ),
+            @ApiResponse(responseCode = "400", description = "독서 캘린더 조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    } )
+    @Deprecated
+    public ResponseEntity<?> getUserBookCalendar(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "사용자 ID를 입력해주세요.", required = true) @PathVariable Long userId,
+            @Parameter(description = "조회할 날짜를 입력해주세요.", example = "2021-11-01", required = true) @PathVariable String date
+    ) {
+        return userBookService.getUserBookCalendar(userPrincipal, userId, date);
     }
 }

--- a/src/main/java/com/nookbook/domain/user_book/application/UserBookService.java
+++ b/src/main/java/com/nookbook/domain/user_book/application/UserBookService.java
@@ -54,14 +54,13 @@ public class UserBookService {
 
     }
 
-    // 특정 챌린지 참가자의 독서 기록(캘린더) 조회
-    public ResponseEntity<?> getUserBookCalendar(UserPrincipal userPrincipal,Long participantId, String date) {
+    // 특정 유저의 독서 기록(캘린더) 조회
+    public ResponseEntity<?> getUserBookCalendar(UserPrincipal userPrincipal,Long userId, String date) {
         validateUser(userPrincipal);
-        Participant participant = participantService.getParticipant(participantId);
-        User participantUser = participant.getUser();
+        User user = getUser(userId);
         // 날짜 형식 판단 메소드
         // YYYY-MM-DD 형식 / YYYY-MM 형식
-        return distinctDateFormat(participantUser, date);
+        return distinctDateFormat(user, date);
 
     }
 
@@ -199,6 +198,12 @@ public class UserBookService {
     // 사용자 검증 메서드
     private User validateUser(UserPrincipal userPrincipal) {
         return userService.findByEmail(userPrincipal.getEmail())
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    // getUser
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
     }
 }


### PR DESCRIPTION
## 👑 Summary
> 어떤 내용의 PR인가요?
- 캘린더 조회 기능 확장에 따른 API 통합

## 🫧 To be noted
> PR을 검토할 때 확인해야 할 사항이 있나요?
- 필요한 파라미터들이 다른 API에서 응답값으로 존재하는가?

## 💫 issue number
> 이슈 번호를 작성해주새요
- #204 

## ☑️ Checklist
> PR 요청 시 체크해주세요.
- [x] label
- [x] issue number
- [x] conflict resolve

## 💡 Comment
> 전달하고 싶은 내용이 있나요?
- API를 분리할지 통합할지 고민을 했었는데, REST의 자원(resource) 설계 원칙에 따라 판단하였습니다.
- 독서 기록은 User의 자원이므로 챌린지나 친구에 종속되지 않는 것이 맞다고 생각하였습니다.
- 명세서 deprecated 처리는 프론트에서 수정 시 수정사항을 비교하기 편하도록 표시해둔 것으로, 후에 수정 완료 시 삭제할 예정입니다