### PR TITLE
[FEAT] 깨우기 기능 호출 제한 기능 구현

### DIFF
--- a/src/main/java/com/nookbook/domain/alarm/application/AlarmService.java
+++ b/src/main/java/com/nookbook/domain/alarm/application/AlarmService.java
@@ -130,7 +130,7 @@ public class AlarmService {
         Alarm alarm = Alarm.create(
                 receiver,
                 sender.getUserId(),
-                AlarmType.CHALLENGE,
+                AlarmType.WAKE_UP,
                 info.template(),
                 info.args(),
                 challenge.getChallengeId()
@@ -186,4 +186,21 @@ public class AlarmService {
         DefaultAssert.isTrue(!alarms.isEmpty(), "삭제할 알림이 없습니다.");
         alarmRepository.deleteAll(alarms);
     }
+
+
+    // 해당 사용자가 보낸 타겟 사용자의 알림 목록 중 가장 최근의 깨우기 알림 생성 시간을 가져오는 메서드
+    // 이 메서드는 알림 목록이 비어있을 경우 null을 반환합니다.
+    // alarmType = WAKE_UP인 알림만 조회합니다.
+    public LocalDateTime getLastWakeUpAlarmTime(User sender, User target) {
+        List<Alarm> alarms = alarmRepository.findTopByUserAndSenderIdAndAlarmTypeOrderByCreatedAtDesc(
+                target, sender.getUserId(), AlarmType.WAKE_UP
+        );
+
+        if (alarms.isEmpty()) {
+            return null; // 알림이 없을 경우 null 반환
+        }
+
+        return alarms.get(0).getCreatedAt(); // 가장 최근 알림의 생성 시간 반환
+    }
+
 }

--- a/src/main/java/com/nookbook/domain/alarm/domain/AlarmType.java
+++ b/src/main/java/com/nookbook/domain/alarm/domain/AlarmType.java
@@ -3,5 +3,6 @@ package com.nookbook.domain.alarm.domain;
 // 알람 타입
 public enum AlarmType {
     FRIEND, // 친구 요청 관련 알림
-    CHALLENGE // 챌린지 초대 관련 알림
+    CHALLENGE, // 챌린지 초대 관련 알림
+    WAKE_UP // 챌린지 참가자 깨우기 알림
 }

--- a/src/main/java/com/nookbook/domain/alarm/domain/repository/AlarmRepository.java
+++ b/src/main/java/com/nookbook/domain/alarm/domain/repository/AlarmRepository.java
@@ -18,4 +18,6 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     Page<Alarm> findByUserAndCreatedAtAfter(User user, LocalDateTime weekAgo, Pageable pageable);
 
     List<Alarm> findByUserAndAlarmTypeAndSenderId(User receiver, AlarmType alarmType, Long userId);
+
+    List<Alarm> findTopByUserAndSenderIdAndAlarmTypeOrderByCreatedAtDesc(User target, Long userId, AlarmType alarmType);
 }

--- a/src/main/java/com/nookbook/domain/alarm/exception/WakeUpRequestTooSoonException.java
+++ b/src/main/java/com/nookbook/domain/alarm/exception/WakeUpRequestTooSoonException.java
@@ -1,0 +1,10 @@
+package com.nookbook.domain.alarm.exception;
+
+import com.nookbook.global.exception.BusinessException;
+import com.nookbook.global.payload.ErrorCode;
+
+public class WakeUpRequestTooSoonException extends BusinessException {
+    public WakeUpRequestTooSoonException() {
+        super(ErrorCode.WAKE_UP_REQUEST_TOO_SOON);
+    }
+}

--- a/src/main/java/com/nookbook/domain/challenge/application/ChallengeService.java
+++ b/src/main/java/com/nookbook/domain/challenge/application/ChallengeService.java
@@ -30,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -238,7 +239,9 @@ public class ChallengeService {
         for(Participant participant : participants) {
             // 참가자가 본인인지 여부 확인 (꺠우기 버튼 disabled 여부를 판단하기 위함)
             boolean isMe = participant.getUser().equals(user);
-            participantStatusListRes.add(getParticipantStatus(participant, isMe));
+            // 각 참가자에 대한 가장 최근 깨우기 시간 조회
+            LocalDateTime lastWakeUpTime = alarmService.getLastWakeUpAlarmTime(user, participant.getUser());
+            participantStatusListRes.add(getParticipantStatus(participant, isMe, lastWakeUpTime));
 
         }
 
@@ -247,7 +250,7 @@ public class ChallengeService {
     }
 
     // UserBook: 사용자가 오늘 기록한 책
-    private ParticipantStatusListRes getParticipantStatus(Participant participant, boolean isMe) {
+    private ParticipantStatusListRes getParticipantStatus(Participant participant, boolean isMe, LocalDateTime lastWakeUpTime) {
 
         // 해당 참가자의 오늘 타이머 목록 조회
         List<Timer> todayTimers = timerRepository.findByUserAndCreatedAt(participant.getUser(), LocalDate.now());
@@ -277,6 +280,7 @@ public class ChallengeService {
                 .participantImage(participant.getUser().getImageUrl()) // 참가자 이미지
                 .isReading(isReading) // 실시간 독서 진행 여부
                 .dailyReadingTime(readTime) // 가장 최근의 독서 시간
+                .lastWakeUpTime(lastWakeUpTime) // 가장 최근의 깨우기 시간
                 .build();
     }
 

--- a/src/main/java/com/nookbook/domain/challenge/dto/response/ParticipantStatusListRes.java
+++ b/src/main/java/com/nookbook/domain/challenge/dto/response/ParticipantStatusListRes.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
@@ -37,4 +39,9 @@ public class ParticipantStatusListRes {
 
     @Schema(type = "hh:mm:ss", example = "02:34:10", description = "참여자 일일 독서 시간 (타이머 기반)")
     private String dailyReadingTime;
+
+    // 가장 최근의 깨우기 시간
+    @Schema(type = "LocalDateTime", example = "2023-10-01T12:00:00", description = "참여자가 마지막으로 깨운 시간")
+    private LocalDateTime lastWakeUpTime;
+
 }

--- a/src/main/java/com/nookbook/global/payload/ErrorCode.java
+++ b/src/main/java/com/nookbook/global/payload/ErrorCode.java
@@ -43,7 +43,8 @@ public enum ErrorCode {
 
     // Alarm (ALM)
     ALARM_PUSH_SEND_FAILED(500, "ALM001", "푸시 알림 전송에 실패했습니다."),
-    EXPO_TOKEN_NOT_FOUND(404, "ALM002", "해당 사용자의 Expo 토큰을 찾을 수 없습니다.");
+    EXPO_TOKEN_NOT_FOUND(404, "ALM002", "해당 사용자의 Expo 토큰을 찾을 수 없습니다."),
+    WAKE_UP_REQUEST_TOO_SOON(400, "ALM003", "깨우기 요청은 3시간에 한 번만 가능합니다."),;
 
     private final String code;
     private final String message;


### PR DESCRIPTION
## 👑 Summary
> 어떤 내용의 PR인가요?
- 깨우기 기능 횟수를 3시간에 한 번으로 제한

## 🫧 To be noted
> PR을 검토할 때 확인해야 할 사항이 있나요?
- 

## 💫 issue number
> 이슈 번호를 작성해주새요
- #221 

## ☑️ Checklist
> PR 요청 시 체크해주세요.
- [ ] label
- [ ] issue number
- [ ] conflict resolve

## 💡 Comment
> 전달하고 싶은 내용이 있나요?
- 다음 내용을 기반으로 작업했습니다
  - 깨우기 API 호출 횟수를 3시간에 한 번으로 제한
  - 챌린지 상세보기에서 각 참가자별 마지막 찌르기 시간 응답 (해당 사용자 : 대상 사용자)
  - 한번도 찌르기를 하지 않은 경우 NULL로 응답
  - 별도의 서버 자체 찌르기 오류 처리 추가