### PR TITLE
Feat/sign in sign up

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
     implementation 'com.github.ben-manes.caffeine:caffeine'
+    implementation 'org.projectlombok:lombok:1.18.28'
 
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
@@ -64,7 +65,10 @@ dependencies {
     implementation 'io.github.jav:expo-server-sdk:1.1.0'
 
     implementation "io.netty:netty-all:4.1.94.Final"
-
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    //mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     if (isMacOS && isAppleSilicon) {
         runtimeOnly "io.netty:netty-resolver-dns-native-macos:4.1.94.Final:osx-aarch_64"
     } else if (isMacOS) {

--- a/src/main/java/com/nookbook/NookBookApplication.java
+++ b/src/main/java/com/nookbook/NookBookApplication.java
@@ -18,6 +18,7 @@ import java.util.TimeZone;
 @PropertySource(value = { "classpath:oauth2/application-oauth2.yml" }, factory = YamlPropertySourceFactory.class)
 @PropertySource(value = { "classpath:s3/application-s3.yml" }, factory = YamlPropertySourceFactory.class)
 @PropertySource(value = { "classpath:book/application-book.yml" }, factory = YamlPropertySourceFactory.class)
+@PropertySource(value = { "classpath:mail/application-mail.yml" }, factory = YamlPropertySourceFactory.class)
 public class NookBookApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/nookbook/domain/auth/application/AuthService.java
+++ b/src/main/java/com/nookbook/domain/auth/application/AuthService.java
@@ -2,13 +2,18 @@ package com.nookbook.domain.auth.application;
 
 import com.nookbook.domain.auth.domain.Token;
 import com.nookbook.domain.auth.domain.repository.TokenRepository;
+import com.nookbook.domain.auth.dto.request.FindNicknameIdReq;
+import com.nookbook.domain.auth.dto.request.ResetPasswordReq;
 import com.nookbook.domain.auth.dto.response.LoginResponse;
 import com.nookbook.domain.user.application.UserService;
 import com.nookbook.domain.user.domain.Provider;
 import com.nookbook.domain.user.domain.Role;
 import com.nookbook.domain.user.domain.User;
 import com.nookbook.domain.user.domain.repository.UserRepository;
+import com.nookbook.domain.user.exception.OAuthUserPasswordResetException;
 import com.nookbook.domain.user.exception.UserNotFoundException;
+import com.nookbook.domain.verification.application.VerificationService;
+import com.nookbook.domain.verification.exception.VerificationNotCompletedException;
 import com.nookbook.global.DefaultAssert;
 import com.nookbook.global.config.security.token.UserPrincipal;
 import com.nookbook.global.config.security.util.JwtTokenUtil;
@@ -36,6 +41,7 @@ public class AuthService {
     private final UserDetailsService userDetailsService;
     private final UserService userService;
     private final PasswordEncoder passwordEncoder;
+    private final VerificationService verificationService;
 
 
     public String verifyIdTokenAndExtractUsername(String idToken, String email) {
@@ -212,6 +218,54 @@ public class AuthService {
         if (token != null) {
             tokenRepository.delete(token);
         }
+    }
+
+    public ResponseEntity<?> findNicknameId(FindNicknameIdReq findNicknameIdReq) {
+        String email = findNicknameIdReq.getEmail();
+
+        if (!verificationService.isVerified(email)) {
+            throw new VerificationNotCompletedException();
+        }
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
+
+        verificationService.removeVerified(email);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(user.getNicknameId())
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @Transactional
+    public ResponseEntity<?> resetPassword(ResetPasswordReq resetPasswordReq) {
+        String email = resetPasswordReq.getEmail();
+
+        if (!verificationService.isVerified(email)) {
+            throw new VerificationNotCompletedException();
+        }
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
+
+        if (user.getProvider() != Provider.local) {
+            throw new OAuthUserPasswordResetException();
+        }
+
+        String encodedPassword = passwordEncoder.encode(resetPasswordReq.getNewPassword());
+        user.updatePassword(encodedPassword);
+
+        verificationService.removeVerified(email);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information("비밀번호가 성공적으로 변경되었습니다.")
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
     }
 
     // 사용자 검증 메서드

--- a/src/main/java/com/nookbook/domain/auth/application/AuthService.java
+++ b/src/main/java/com/nookbook/domain/auth/application/AuthService.java
@@ -5,9 +5,11 @@ import com.nookbook.domain.auth.domain.repository.TokenRepository;
 import com.nookbook.domain.auth.dto.response.LoginResponse;
 import com.nookbook.domain.user.application.UserService;
 import com.nookbook.domain.user.domain.Provider;
+import com.nookbook.domain.user.domain.Role;
 import com.nookbook.domain.user.domain.User;
 import com.nookbook.domain.user.domain.repository.UserRepository;
 import com.nookbook.domain.user.exception.UserNotFoundException;
+import com.nookbook.global.DefaultAssert;
 import com.nookbook.global.config.security.token.UserPrincipal;
 import com.nookbook.global.config.security.util.JwtTokenUtil;
 import com.nookbook.global.payload.ApiResponse;
@@ -15,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +35,7 @@ public class AuthService {
     private final IdTokenVerifier idTokenVerifier;
     private final UserDetailsService userDetailsService;
     private final UserService userService;
+    private final PasswordEncoder passwordEncoder;
 
 
     public String verifyIdTokenAndExtractUsername(String idToken, String email) {
@@ -126,6 +130,76 @@ public class AuthService {
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)
                 .information("회원 탈퇴 성공")
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @Transactional
+    public ResponseEntity<?> signUp(String email, String password, String nickname) {
+        // 이메일 중복 체크
+        Optional<User> existingUser = userRepository.findByEmail(email);
+        DefaultAssert.isTrue(existingUser.isEmpty(), "이미 사용 중인 이메일입니다.");
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(password);
+
+        // 사용자 생성
+        User user = User.builder()
+                .email(email)
+                .password(encodedPassword)
+                .nickname(nickname)
+                .provider(Provider.local)
+                .providerId(email)
+                .role(Role.USER)
+                .build();
+
+        userRepository.save(user);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information("회원가입이 완료되었습니다.")
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @Transactional
+    public ResponseEntity<?> localLogin(String email, String password) {
+        // 사용자 조회
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다."));
+
+        // Provider 검증 (local 계정인지 확인)
+        DefaultAssert.isTrue(user.getProvider() == Provider.local, "소셜 로그인 계정입니다. 소셜 로그인을 이용해주세요.");
+
+        // 비밀번호 검증
+        DefaultAssert.isTrue(passwordEncoder.matches(password, user.getPassword()), "이메일 또는 비밀번호가 올바르지 않습니다.");
+
+        // JWT 토큰 생성
+        String accessToken = jwtTokenUtil.generateToken(new HashMap<>(), email);
+        String refreshToken = jwtTokenUtil.generateRefreshToken(new HashMap<>(), email);
+
+        // Refresh token DB에 저장 (기존 토큰이 있으면 업데이트)
+        Token existingToken = tokenRepository.findByEmail(email);
+        if (existingToken != null) {
+            tokenRepository.delete(existingToken);
+        }
+
+        Token tokenEntity = Token.builder()
+                .email(email)
+                .refreshToken(refreshToken)
+                .build();
+        tokenRepository.save(tokenEntity);
+
+        LoginResponse loginResponse = LoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(loginResponse)
                 .build();
 
         return ResponseEntity.ok(apiResponse);

--- a/src/main/java/com/nookbook/domain/auth/dto/request/FindNicknameIdReq.java
+++ b/src/main/java/com/nookbook/domain/auth/dto/request/FindNicknameIdReq.java
@@ -1,0 +1,21 @@
+package com.nookbook.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class FindNicknameIdReq {
+
+    @Schema(type = "string", example = "user@example.com", description = "사용자 이메일")
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+}

--- a/src/main/java/com/nookbook/domain/auth/dto/request/LocalSignInReq.java
+++ b/src/main/java/com/nookbook/domain/auth/dto/request/LocalSignInReq.java
@@ -1,0 +1,26 @@
+package com.nookbook.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class LocalSignInReq {
+
+    @Schema(type = "string", example = "user@example.com", description = "사용자 이메일")
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @Schema(type = "string", example = "password123!", description = "비밀번호")
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+}
+

--- a/src/main/java/com/nookbook/domain/auth/dto/request/ResetPasswordReq.java
+++ b/src/main/java/com/nookbook/domain/auth/dto/request/ResetPasswordReq.java
@@ -1,0 +1,27 @@
+package com.nookbook.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ResetPasswordReq {
+
+    @Schema(type = "string", example = "user@example.com", description = "사용자 이메일")
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @Schema(type = "string", example = "newPassword123!", description = "새 비밀번호 (8자 이상)")
+    @NotBlank(message = "새 비밀번호는 필수입니다.")
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    private String newPassword;
+}

--- a/src/main/java/com/nookbook/domain/auth/dto/request/SignUpReq.java
+++ b/src/main/java/com/nookbook/domain/auth/dto/request/SignUpReq.java
@@ -1,0 +1,33 @@
+package com.nookbook.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class SignUpReq {
+
+    @Schema(type = "string", example = "user@example.com", description = "사용자 이메일")
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @Schema(type = "string", example = "password123!", description = "비밀번호 (8자 이상)")
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    private String password;
+
+    @Schema(type = "string", example = "홍길동", description = "닉네임")
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하여야 합니다.")
+    private String nickname;
+}
+

--- a/src/main/java/com/nookbook/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/nookbook/domain/auth/presentation/AuthController.java
@@ -1,7 +1,9 @@
 package com.nookbook.domain.auth.presentation;
 
 import com.nookbook.domain.auth.application.AuthService;
+import com.nookbook.domain.auth.dto.request.LocalSignInReq;
 import com.nookbook.domain.auth.dto.request.SignInReq;
+import com.nookbook.domain.auth.dto.request.SignUpReq;
 import com.nookbook.domain.auth.dto.response.LoginResponse;
 import com.nookbook.global.config.security.token.CurrentUser;
 import com.nookbook.global.config.security.token.UserPrincipal;
@@ -15,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -54,6 +57,38 @@ public class AuthController {
             return authService.loginWithIdToken(accessToken, email);
         } catch (RuntimeException e) {
             ErrorCode errorCode = ErrorCode.INVALID_TOKEN;
+            ErrorResponse errorResponse = ErrorResponse.of(errorCode, e.getMessage());
+            return ResponseEntity.badRequest().body(errorResponse);
+        }
+    }
+
+    @Operation(summary = "자체 회원가입 API", description = "이메일과 비밀번호로 회원가입합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원가입 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "회원가입 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @PostMapping("/signup")
+    public ResponseEntity<?> signUp(@Valid @RequestBody SignUpReq signUpReq) {
+        try {
+            return authService.signUp(signUpReq.getEmail(), signUpReq.getPassword(), signUpReq.getNickname());
+        } catch (Exception e) {
+            ErrorCode errorCode = ErrorCode.INVALID_PARAMETER;
+            ErrorResponse errorResponse = ErrorResponse.of(errorCode, e.getMessage());
+            return ResponseEntity.badRequest().body(errorResponse);
+        }
+    }
+
+    @Operation(summary = "자체 로그인 API", description = "이메일과 비밀번호로 로그인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = LoginResponse.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "로그인 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @PostMapping("/login/local")
+    public ResponseEntity<?> localLogin(@Valid @RequestBody LocalSignInReq localSignInReq) {
+        try {
+            return authService.localLogin(localSignInReq.getEmail(), localSignInReq.getPassword());
+        } catch (Exception e) {
+            ErrorCode errorCode = ErrorCode.INVALID_PARAMETER;
             ErrorResponse errorResponse = ErrorResponse.of(errorCode, e.getMessage());
             return ResponseEntity.badRequest().body(errorResponse);
         }

--- a/src/main/java/com/nookbook/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/nookbook/domain/auth/presentation/AuthController.java
@@ -1,7 +1,9 @@
 package com.nookbook.domain.auth.presentation;
 
 import com.nookbook.domain.auth.application.AuthService;
+import com.nookbook.domain.auth.dto.request.FindNicknameIdReq;
 import com.nookbook.domain.auth.dto.request.LocalSignInReq;
+import com.nookbook.domain.auth.dto.request.ResetPasswordReq;
 import com.nookbook.domain.auth.dto.request.SignInReq;
 import com.nookbook.domain.auth.dto.request.SignUpReq;
 import com.nookbook.domain.auth.dto.response.LoginResponse;
@@ -92,6 +94,26 @@ public class AuthController {
             ErrorResponse errorResponse = ErrorResponse.of(errorCode, e.getMessage());
             return ResponseEntity.badRequest().body(errorResponse);
         }
+    }
+
+    @Operation(summary = "닉네임 아이디 찾기 API", description = "이메일 인증 완료 후 해당 이메일에 연결된 닉네임 아이디(nicknameId)를 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "닉네임 아이디 찾기 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "닉네임 아이디 찾기 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @PostMapping("/find-nickname-id")
+    public ResponseEntity<?> findNicknameId(@Valid @RequestBody FindNicknameIdReq findNicknameIdReq) {
+        return authService.findNicknameId(findNicknameIdReq);
+    }
+
+    @Operation(summary = "비밀번호 변경 API", description = "이메일 인증 완료 후 새 비밀번호로 변경합니다. (자체 로그인 계정만 가능)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "비밀번호 변경 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @PostMapping("/reset-password")
+    public ResponseEntity<?> resetPassword(@Valid @RequestBody ResetPasswordReq resetPasswordReq) {
+        return authService.resetPassword(resetPasswordReq);
     }
 
     @Operation(summary = "로그아웃 API", description = "로그아웃 API입니다.")

--- a/src/main/java/com/nookbook/domain/mail/application/MailService.java
+++ b/src/main/java/com/nookbook/domain/mail/application/MailService.java
@@ -1,0 +1,54 @@
+package com.nookbook.domain.mail.application;
+
+import com.nookbook.domain.verification.exception.EmailSendFailedException;
+import com.nookbook.global.mail.MailTemplateBuilder;
+import com.nookbook.global.util.MailHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MailService {
+
+    private final JavaMailSender mailSender;
+    private final MailTemplateBuilder mailTemplateBuilder;
+
+    @Value("${spring.mail.username}")
+    private String from;
+    @Value("${spring.mail.verification.subject}")
+    private String subject;
+    @Value("${spring.mail.verification.expire-minutes}")
+    private int verificationExpireMinutes;
+
+    public void sendPasswordResetVerificationEmail(String email, String code) {
+        String content = mailTemplateBuilder.buildPasswordResetEmail(
+                code,
+                verificationExpireMinutes
+        );
+
+        sendMail(email, subject, content);
+    }
+
+    public void sendMail(String to, String subject, String content) {
+        sendHtmlMail(to, subject, content);
+    }
+
+    private void sendHtmlMail(String to, String subject, String content) {
+        try {
+            MailHandler mailHandler = new MailHandler(mailSender);
+            mailHandler.setTo(to);
+            mailHandler.setSubject(subject);
+            mailHandler.setText(content, true);
+            mailHandler.setFrom(from);
+            mailHandler.send();
+
+        } catch (Exception ex) {
+            log.error("Failed to send email. to={}, subject={}", to, subject, ex);
+            throw new EmailSendFailedException();
+        }
+    }
+}

--- a/src/main/java/com/nookbook/domain/mail/dto/req/SendCodeReq.java
+++ b/src/main/java/com/nookbook/domain/mail/dto/req/SendCodeReq.java
@@ -1,0 +1,21 @@
+package com.nookbook.domain.mail.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class SendCodeReq {
+
+    @Schema(type = "string", example = "user@example.com", description = "인증 코드를 받을 이메일 주소")
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+}

--- a/src/main/java/com/nookbook/domain/user/domain/User.java
+++ b/src/main/java/com/nookbook/domain/user/domain/User.java
@@ -141,4 +141,8 @@ public class User extends BaseEntity {
         this.expoPushToken = expoPushToken;
     }
 
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
 }

--- a/src/main/java/com/nookbook/domain/user/exception/OAuthUserPasswordResetException.java
+++ b/src/main/java/com/nookbook/domain/user/exception/OAuthUserPasswordResetException.java
@@ -1,0 +1,10 @@
+package com.nookbook.domain.user.exception;
+
+import com.nookbook.global.exception.BusinessException;
+import com.nookbook.global.payload.ErrorCode;
+
+public class OAuthUserPasswordResetException extends BusinessException {
+    public OAuthUserPasswordResetException() {
+        super(ErrorCode.OAUTH_USER_PASSWORD_RESET);
+    }
+}

--- a/src/main/java/com/nookbook/domain/verification/application/VerificationService.java
+++ b/src/main/java/com/nookbook/domain/verification/application/VerificationService.java
@@ -1,0 +1,76 @@
+package com.nookbook.domain.verification.application;
+
+import com.nookbook.domain.mail.application.MailService;
+import com.nookbook.domain.mail.dto.req.SendCodeReq;
+import com.nookbook.domain.verification.dto.req.VerificationCodeReq;
+import com.nookbook.domain.verification.exception.VerificationCodeExpiredException;
+import com.nookbook.domain.verification.exception.VerificationCodeMismatchException;
+import com.nookbook.global.payload.Message;
+import com.nookbook.global.util.RandomCodeGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VerificationService {
+
+    private static final String REDIS_KEY_PREFIX = "verification:email:";
+    private static final String VERIFIED_KEY_PREFIX = "verification:verified:";
+    private static final int CODE_LENGTH = 6;
+    private static final long CODE_TTL_MINUTES = 5;
+    private static final long VERIFIED_TTL_MINUTES = 10;
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final MailService mailService;
+
+    public ResponseEntity<Message> sendVerificationCode(SendCodeReq sendCodeReq) {
+        String email = sendCodeReq.getEmail();
+        String code = RandomCodeGenerator.generateCode(CODE_LENGTH);
+
+        String redisKey = REDIS_KEY_PREFIX + email;
+        redisTemplate.opsForValue().set(redisKey, code, CODE_TTL_MINUTES, TimeUnit.MINUTES);
+
+        mailService.sendPasswordResetVerificationEmail(email, code);
+
+        return ResponseEntity.ok(new Message("인증 코드가 이메일로 발송되었습니다."));
+    }
+
+    public ResponseEntity<Message> verifyCode(VerificationCodeReq verificationCodeReq) {
+        String email = verificationCodeReq.getEmail();
+        String code = verificationCodeReq.getCode();
+
+        String redisKey = REDIS_KEY_PREFIX + email;
+        Object storedCode = redisTemplate.opsForValue().get(redisKey);
+
+        if (storedCode == null) {
+            throw new VerificationCodeExpiredException();
+        }
+
+        if (!storedCode.toString().equals(code)) {
+            throw new VerificationCodeMismatchException();
+        }
+
+        redisTemplate.delete(redisKey);
+
+        String verifiedKey = VERIFIED_KEY_PREFIX + email;
+        redisTemplate.opsForValue().set(verifiedKey, "true", VERIFIED_TTL_MINUTES, TimeUnit.MINUTES);
+
+        return ResponseEntity.ok(new Message("인증이 완료되었습니다."));
+    }
+
+    public boolean isVerified(String email) {
+        String verifiedKey = VERIFIED_KEY_PREFIX + email;
+        return Boolean.TRUE.equals(redisTemplate.hasKey(verifiedKey));
+    }
+
+    public void removeVerified(String email) {
+        String verifiedKey = VERIFIED_KEY_PREFIX + email;
+        redisTemplate.delete(verifiedKey);
+    }
+}

--- a/src/main/java/com/nookbook/domain/verification/dto/req/VerificationCodeReq.java
+++ b/src/main/java/com/nookbook/domain/verification/dto/req/VerificationCodeReq.java
@@ -1,0 +1,25 @@
+package com.nookbook.domain.verification.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class VerificationCodeReq {
+
+    @Schema(type = "string", example = "user@example.com", description = "인증 코드를 받은 이메일 주소")
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @Schema(type = "string", example = "A3B7K9", description = "6자리 인증 코드")
+    @NotBlank(message = "인증 코드는 필수 입력값입니다.")
+    private String code;
+}

--- a/src/main/java/com/nookbook/domain/verification/exception/EmailSendFailedException.java
+++ b/src/main/java/com/nookbook/domain/verification/exception/EmailSendFailedException.java
@@ -1,0 +1,10 @@
+package com.nookbook.domain.verification.exception;
+
+import com.nookbook.global.exception.BusinessException;
+import com.nookbook.global.payload.ErrorCode;
+
+public class EmailSendFailedException extends BusinessException {
+    public EmailSendFailedException() {
+        super(ErrorCode.EMAIL_SEND_FAILED);
+    }
+}

--- a/src/main/java/com/nookbook/domain/verification/exception/VerificationCodeExpiredException.java
+++ b/src/main/java/com/nookbook/domain/verification/exception/VerificationCodeExpiredException.java
@@ -1,0 +1,10 @@
+package com.nookbook.domain.verification.exception;
+
+import com.nookbook.global.exception.BusinessException;
+import com.nookbook.global.payload.ErrorCode;
+
+public class VerificationCodeExpiredException extends BusinessException {
+    public VerificationCodeExpiredException() {
+        super(ErrorCode.VERIFICATION_CODE_EXPIRED);
+    }
+}

--- a/src/main/java/com/nookbook/domain/verification/exception/VerificationCodeMismatchException.java
+++ b/src/main/java/com/nookbook/domain/verification/exception/VerificationCodeMismatchException.java
@@ -1,0 +1,10 @@
+package com.nookbook.domain.verification.exception;
+
+import com.nookbook.global.exception.BusinessException;
+import com.nookbook.global.payload.ErrorCode;
+
+public class VerificationCodeMismatchException extends BusinessException {
+    public VerificationCodeMismatchException() {
+        super(ErrorCode.VERIFICATION_CODE_MISMATCH);
+    }
+}

--- a/src/main/java/com/nookbook/domain/verification/exception/VerificationNotCompletedException.java
+++ b/src/main/java/com/nookbook/domain/verification/exception/VerificationNotCompletedException.java
@@ -1,0 +1,10 @@
+package com.nookbook.domain.verification.exception;
+
+import com.nookbook.global.exception.BusinessException;
+import com.nookbook.global.payload.ErrorCode;
+
+public class VerificationNotCompletedException extends BusinessException {
+    public VerificationNotCompletedException() {
+        super(ErrorCode.VERIFICATION_NOT_COMPLETED);
+    }
+}

--- a/src/main/java/com/nookbook/domain/verification/presentation/VerificationController.java
+++ b/src/main/java/com/nookbook/domain/verification/presentation/VerificationController.java
@@ -1,0 +1,50 @@
+package com.nookbook.domain.verification.presentation;
+
+import com.nookbook.domain.mail.dto.req.SendCodeReq;
+import com.nookbook.domain.verification.application.VerificationService;
+import com.nookbook.domain.verification.dto.req.VerificationCodeReq;
+import com.nookbook.global.payload.ErrorResponse;
+import com.nookbook.global.payload.Message;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Verification", description = "이메일 인증 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/verification")
+public class VerificationController {
+
+    private final VerificationService verificationService;
+
+    @Operation(summary = "인증 코드 발송 API", description = "이메일로 인증 코드를 발송합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "인증 코드 발송 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+            @ApiResponse(responseCode = "500", description = "이메일 전송 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @PostMapping("/code")
+    public ResponseEntity<Message> sendVerificationCode(@Valid @RequestBody SendCodeReq sendCodeReq) {
+        return verificationService.sendVerificationCode(sendCodeReq);
+    }
+
+    @Operation(summary = "인증 코드 확인 API", description = "이메일로 발송된 인증 코드를 확인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "인증 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "인증 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @PostMapping("/code/check")
+    public ResponseEntity<Message> verifyCode(@Valid @RequestBody VerificationCodeReq verificationCodeReq) {
+        return verificationService.verifyCode(verificationCodeReq);
+    }
+}

--- a/src/main/java/com/nookbook/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/nookbook/global/config/security/SecurityConfig.java
@@ -80,7 +80,7 @@ public class SecurityConfig {
                         .permitAll()
                         .requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**")
                         .permitAll()
-                        .requestMatchers("/auth/login", "/auth/signup", "/auth/login/local", "/api/v1/users/exists", "/api/v1/verification/**")
+                        .requestMatchers("/auth/login", "/auth/signup", "/auth/login/local", "/auth/find-nickname-id", "/auth/reset-password", "/api/v1/users/exists", "/api/v1/verification/**")
                         .permitAll()
                         .anyRequest()
                         .authenticated())

--- a/src/main/java/com/nookbook/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/nookbook/global/config/security/SecurityConfig.java
@@ -80,7 +80,7 @@ public class SecurityConfig {
                         .permitAll()
                         .requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**")
                         .permitAll()
-                        .requestMatchers("/auth/login", "/api/v1/users/exists")
+                        .requestMatchers("/auth/login", "/auth/signup", "/auth/login/local", "/api/v1/users/exists")
                         .permitAll()
                         .anyRequest()
                         .authenticated())

--- a/src/main/java/com/nookbook/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/nookbook/global/config/security/SecurityConfig.java
@@ -80,7 +80,7 @@ public class SecurityConfig {
                         .permitAll()
                         .requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**")
                         .permitAll()
-                        .requestMatchers("/auth/login", "/auth/signup", "/auth/login/local", "/api/v1/users/exists")
+                        .requestMatchers("/auth/login", "/auth/signup", "/auth/login/local", "/api/v1/users/exists", "/api/v1/verification/**")
                         .permitAll()
                         .anyRequest()
                         .authenticated())

--- a/src/main/java/com/nookbook/global/mail/MailTemplateBuilder.java
+++ b/src/main/java/com/nookbook/global/mail/MailTemplateBuilder.java
@@ -1,0 +1,22 @@
+package com.nookbook.global.mail;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MailTemplateBuilder {
+
+    private final MailTemplateLoader mailTemplateLoader;
+
+    public String buildPasswordResetEmail(String certNo, int minutes) {
+
+        String fileName = "password_reset" + ".html";
+
+        String template = mailTemplateLoader.load(fileName);
+
+        return template
+                .replace("{{CODE}}", certNo)
+                .replace("{{MINUTES}}", String.valueOf(minutes));
+    }
+}

--- a/src/main/java/com/nookbook/global/mail/MailTemplateLoader.java
+++ b/src/main/java/com/nookbook/global/mail/MailTemplateLoader.java
@@ -1,0 +1,25 @@
+package com.nookbook.global.mail;
+
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class MailTemplateLoader {
+
+    public String load(String fileName) {
+        try {
+            ClassPathResource resource =
+                    new ClassPathResource("templates/mail/" + fileName);
+
+            return new String(
+                    resource.getInputStream().readAllBytes(),
+                    StandardCharsets.UTF_8
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load email template: " + fileName, e);
+        }
+    }
+}

--- a/src/main/java/com/nookbook/global/payload/ErrorCode.java
+++ b/src/main/java/com/nookbook/global/payload/ErrorCode.java
@@ -49,7 +49,11 @@ public enum ErrorCode {
     // Verification (VRF)
     VERIFICATION_CODE_EXPIRED(400, "VRF001", "인증 코드가 만료되었거나 존재하지 않습니다."),
     VERIFICATION_CODE_MISMATCH(400, "VRF002", "인증 코드가 일치하지 않습니다."),
-    EMAIL_SEND_FAILED(500, "VRF003", "이메일 전송에 실패했습니다."),;
+    EMAIL_SEND_FAILED(500, "VRF003", "이메일 전송에 실패했습니다."),
+    VERIFICATION_NOT_COMPLETED(400, "VRF004", "이메일 인증이 완료되지 않았습니다."),
+
+    // User (USR) - additional
+    OAUTH_USER_PASSWORD_RESET(400, "USR003", "소셜 로그인 계정은 비밀번호를 변경할 수 없습니다."),;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/nookbook/global/payload/ErrorCode.java
+++ b/src/main/java/com/nookbook/global/payload/ErrorCode.java
@@ -44,7 +44,12 @@ public enum ErrorCode {
     // Alarm (ALM)
     ALARM_PUSH_SEND_FAILED(500, "ALM001", "푸시 알림 전송에 실패했습니다."),
     EXPO_TOKEN_NOT_FOUND(404, "ALM002", "해당 사용자의 Expo 토큰을 찾을 수 없습니다."),
-    WAKE_UP_REQUEST_TOO_SOON(400, "ALM003", "깨우기 요청은 3시간에 한 번만 가능합니다."),;
+    WAKE_UP_REQUEST_TOO_SOON(400, "ALM003", "깨우기 요청은 3시간에 한 번만 가능합니다."),
+
+    // Verification (VRF)
+    VERIFICATION_CODE_EXPIRED(400, "VRF001", "인증 코드가 만료되었거나 존재하지 않습니다."),
+    VERIFICATION_CODE_MISMATCH(400, "VRF002", "인증 코드가 일치하지 않습니다."),
+    EMAIL_SEND_FAILED(500, "VRF003", "이메일 전송에 실패했습니다."),;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/nookbook/global/util/MailHandler.java
+++ b/src/main/java/com/nookbook/global/util/MailHandler.java
@@ -1,0 +1,80 @@
+package com.nookbook.global.util;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import com.nookbook.domain.verification.exception.EmailSendFailedException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+
+
+@Slf4j
+public class MailHandler {
+    private JavaMailSender mailSender;
+    private MimeMessage mimeMessage;
+    private MimeMessageHelper mimeMessageHelper;
+
+
+    public MailHandler(JavaMailSender mailSender) throws MessagingException {
+        this.mailSender = mailSender;
+        this.mimeMessage = mailSender.createMimeMessage();
+        this.mimeMessageHelper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+    }
+
+
+    // Send mail
+    public void send() {
+        try {
+            mailSender.send(mimeMessage);
+        } catch (Exception ex) {
+            log.error(ex.getMessage());
+            throw new EmailSendFailedException();
+        }
+    }
+
+    // Sender address
+    public void setFrom(String fromAddress) throws MessagingException {
+        mimeMessageHelper.setFrom(new InternetAddress(fromAddress));
+    }
+
+    // Recipient address
+    public void setTo(String toAddress) throws MessagingException {
+        mimeMessageHelper.setTo(toAddress);
+    }
+
+    // Recipient addresses
+    public void setTo(String[] toAddresses) throws MessagingException {
+        mimeMessageHelper.setTo(toAddresses);
+    }
+
+    // Subject
+    public void setSubject(String subject) throws MessagingException {
+        mimeMessageHelper.setSubject(subject);
+    }
+
+    // Body content
+    public void setText(String text, boolean useHtml) throws MessagingException {
+        mimeMessageHelper.setText(text, useHtml);
+    }
+
+    // Attachment
+    public void setAttach(MultipartFile attachmentFile) throws IOException, MessagingException {
+        mimeMessageHelper.addAttachment(Objects.requireNonNull(attachmentFile.getOriginalFilename()), attachmentFile);
+    }
+
+    // Inline image
+    public void setInline(String contentId, String pathToInline) throws IOException, MessagingException {
+        File file = new ClassPathResource(pathToInline).getFile();
+        FileSystemResource fileSystemResource = new FileSystemResource(file);
+
+        mimeMessageHelper.addInline(contentId, fileSystemResource);
+    }
+
+}

--- a/src/main/java/com/nookbook/global/util/RandomCodeGenerator.java
+++ b/src/main/java/com/nookbook/global/util/RandomCodeGenerator.java
@@ -1,0 +1,49 @@
+package com.nookbook.global.util;
+
+
+import java.security.SecureRandom;
+
+public class RandomCodeGenerator {
+    private static final SecureRandom secureRandom = new SecureRandom();
+    // exclude 1, I and 0, O to avoid confusion
+    private static final String CHAR_POOL = "ABCDEFGHJKLMNPQRSTUVWXYZ";
+    private static final String NUM_POOL = "23456789";
+
+    // only numbers
+    public static String generateRandomNum(int length) {
+        int maxValue = (int) Math.pow(10, length);
+        return String.format("%0" + length + "d", secureRandom.nextInt(maxValue));
+    }
+
+    // numbers and uppercase letters
+    public static String generateCode(int length) {
+
+        int half = length / 2;
+        StringBuilder sb = new StringBuilder(length);
+
+        // 1. char 3
+        for (int i = 0; i < half; i++) {
+            int idx = secureRandom.nextInt(CHAR_POOL.length());
+            sb.append(CHAR_POOL.charAt(idx));
+        }
+
+        // 2. num 3
+        for (int i = 0; i < half; i++) {
+            int idx = secureRandom.nextInt(NUM_POOL.length());
+            sb.append(NUM_POOL.charAt(idx));
+        }
+
+        // 3. shuffle
+        char[] chars = sb.toString().toCharArray();
+
+        for (int i = chars.length - 1; i > 0; i--) {
+            int j = secureRandom.nextInt(i + 1);
+
+            char temp = chars[i];
+            chars[i] = chars[j];
+            chars[j] = temp;
+        }
+
+        return new String(chars);
+    }
+}

--- a/src/main/java/com/nookbook/infrastructure/redis/config/RedisConfig.java
+++ b/src/main/java/com/nookbook/infrastructure/redis/config/RedisConfig.java
@@ -1,0 +1,47 @@
+package com.nookbook.infrastructure.redis.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Value("${spring.redis.password}")
+    private String password; // 비밀번호 추가
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        config.setPassword(password); // 비밀번호 설정
+
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+
+        // Key와 Hash Key는 String으로 저장
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+
+        // Value와 Hash Value도 String으로 저장
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+}

--- a/src/main/resources/templates/mail/password_reset.html
+++ b/src/main/resources/templates/mail/password_reset.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+</head>
+<body style="font-family: Arial, sans-serif; max-width: 480px; margin: auto; padding: 24px; color: #333;">
+
+<h2 style="margin-bottom: 16px;">Password Reset Verification</h2>
+
+<p style="font-size: 14px; line-height: 1.6;">
+    Please use the verification code below to reset your password.
+</p>
+
+<div style="margin: 24px 0; padding: 18px; background-color: #f5f7fa; border-radius: 8px; text-align: center;">
+    <div style="font-size: 28px; font-weight: bold; letter-spacing: 6px;">
+        {{CODE}}
+    </div>
+</div>
+
+<p style="font-size: 13px; color: #666;">
+    This code will expire in {{MINUTES}} minutes.
+</p>
+
+<p style="font-size: 13px; color: #666;">
+    If you did not request a password reset, please ignore this email.
+</p>
+
+</body>
+</html>


### PR DESCRIPTION
## 👑 Summary
> 어떤 내용의 PR인가요? 
-  자체 회원가입/로그인, 이메일 인증, 닉네임 아이디 찾기, 비밀번호 재설정 기능 구현

## 🫧 To be noted
> PR을 검토할 때 확인해야 할 사항이 있나요?
  - 닉네임 아이디 찾기(/auth/find-nickname-id)와 비밀번호 재설정(/auth/reset-password)은 이메일 인증 API(/api/v1/verification/code, /code/check)를 선행
  호출해야 합니다.
  - 비밀번호 재설정은 local 계정만 가능하며, 소셜 로그인 계정은 OAuthUserPasswordResetException이 발생합니다.

## 💫 issue number
> 이슈 번호를 작성해주새요
- #233 

## ☑️ Checklist
> PR 요청 시 체크해주세요.
- [x] label
- [x] issue number
- [x] conflict resolve

## 💡 Comment
> 전달하고 싶은 내용이 있나요?
-  인증 상태는 Redis에 10분 TTL로 저장되며, 기능 사용 후 즉시 삭제됩니다.
- redis 설정 및 mail 설정 추가로 인해 수정/추가된 yml 파일이 존재합니다. 
  - application-database.yml (기존 내용에 추가)
  - application-mail.yml (신규 추가)